### PR TITLE
Respect global API prefix for papers routes

### DIFF
--- a/backend/app/api/papers.py
+++ b/backend/app/api/papers.py
@@ -9,7 +9,7 @@ from app.models.paper import Paper, PaperCreate
 from app.services.papers import create_paper, get_paper, list_papers
 
 
-router = APIRouter(prefix="/api/papers", tags=["papers"])
+router = APIRouter(prefix="/papers", tags=["papers"])
 
 
 @router.get("", response_model=List[Paper])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,7 +67,7 @@ def create_app() -> FastAPI:
             print(f"Shutdown DB pool close failed: {exc}")
 
     # Routers
-    app.include_router(papers_router)
+    app.include_router(papers_router, prefix=settings.api_prefix)
 
     return app
 


### PR DESCRIPTION
## Summary
- update the papers API router to only declare the resource-specific prefix
- include the papers router with the configurable API prefix so environment overrides apply

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc51cd00fc83218d1058cb806bd912