### PR TITLE
Add graph entity models, migration, and APIs

### DIFF
--- a/backend/app/api/concepts.py
+++ b/backend/app/api/concepts.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.concept import Concept, ConceptCreate
+from app.services.concepts import create_concept, get_concept, list_concepts
+
+
+router = APIRouter(prefix="/concepts", tags=["concepts"])
+
+
+@router.get("", response_model=List[Concept])
+@router.get("/", response_model=List[Concept])
+async def api_list_concepts(
+    paper_id: UUID = Query(..., description="Filter concepts extracted from a paper"),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    return await list_concepts(paper_id=paper_id, limit=limit, offset=offset)
+
+
+@router.post("", response_model=Concept, status_code=201)
+@router.post("/", response_model=Concept, status_code=201)
+async def api_create_concept(data: ConceptCreate) -> Concept:
+    return await create_concept(data)
+
+
+@router.get("/{concept_id}", response_model=Concept)
+async def api_get_concept(concept_id: UUID) -> Concept:
+    concept = await get_concept(concept_id)
+    if not concept:
+        raise HTTPException(status_code=404, detail="Concept not found")
+    return concept
+

--- a/backend/app/api/evidence.py
+++ b/backend/app/api/evidence.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.evidence import Evidence, EvidenceCreate
+from app.services.evidence import create_evidence, get_evidence, list_evidence
+
+
+router = APIRouter(prefix="/evidence", tags=["evidence"])
+
+
+@router.get("", response_model=List[Evidence])
+@router.get("/", response_model=List[Evidence])
+async def api_list_evidence(
+    paper_id: UUID = Query(..., description="Filter evidence for a paper"),
+    section_id: Optional[UUID] = Query(default=None, description="Filter by originating section"),
+    concept_id: Optional[UUID] = Query(default=None, description="Filter by linked concept"),
+    relation_id: Optional[UUID] = Query(default=None, description="Filter by relation context"),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    return await list_evidence(
+        paper_id=paper_id,
+        section_id=section_id,
+        concept_id=concept_id,
+        relation_id=relation_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("", response_model=Evidence, status_code=201)
+@router.post("/", response_model=Evidence, status_code=201)
+async def api_create_evidence(data: EvidenceCreate) -> Evidence:
+    return await create_evidence(data)
+
+
+@router.get("/{evidence_id}", response_model=Evidence)
+async def api_get_evidence(evidence_id: UUID) -> Evidence:
+    evidence = await get_evidence(evidence_id)
+    if not evidence:
+        raise HTTPException(status_code=404, detail="Evidence not found")
+    return evidence
+

--- a/backend/app/api/relations.py
+++ b/backend/app/api/relations.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.relation import Relation, RelationCreate
+from app.services.relations import create_relation, get_relation, list_relations
+
+
+router = APIRouter(prefix="/relations", tags=["relations"])
+
+
+@router.get("", response_model=List[Relation])
+@router.get("/", response_model=List[Relation])
+async def api_list_relations(
+    paper_id: UUID = Query(..., description="Filter relations for a paper"),
+    concept_id: Optional[UUID] = Query(default=None, description="Filter by primary concept"),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    return await list_relations(
+        paper_id=paper_id,
+        concept_id=concept_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("", response_model=Relation, status_code=201)
+@router.post("/", response_model=Relation, status_code=201)
+async def api_create_relation(data: RelationCreate) -> Relation:
+    return await create_relation(data)
+
+
+@router.get("/{relation_id}", response_model=Relation)
+async def api_get_relation(relation_id: UUID) -> Relation:
+    relation = await get_relation(relation_id)
+    if not relation:
+        raise HTTPException(status_code=404, detail="Relation not found")
+    return relation
+

--- a/backend/app/api/sections.py
+++ b/backend/app/api/sections.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.section import Section, SectionCreate
+from app.services.sections import create_section, get_section, list_sections
+
+
+router = APIRouter(prefix="/sections", tags=["sections"])
+
+
+@router.get("", response_model=List[Section])
+@router.get("/", response_model=List[Section])
+async def api_list_sections(
+    paper_id: UUID = Query(..., description="Filter sections for a paper"),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    return await list_sections(paper_id=paper_id, limit=limit, offset=offset)
+
+
+@router.post("", response_model=Section, status_code=201)
+@router.post("/", response_model=Section, status_code=201)
+async def api_create_section(data: SectionCreate) -> Section:
+    return await create_section(data)
+
+
+@router.get("/{section_id}", response_model=Section)
+async def api_get_section(section_id: UUID) -> Section:
+    section = await get_section(section_id)
+    if not section:
+        raise HTTPException(status_code=404, detail="Section not found")
+    return section
+

--- a/backend/app/db/migrations/0002_graph_entities.sql
+++ b/backend/app/db/migrations/0002_graph_entities.sql
@@ -1,0 +1,70 @@
+-- Sections table captures parsed chunks from papers
+CREATE TABLE IF NOT EXISTS sections (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    title TEXT,
+    content TEXT NOT NULL,
+    char_start INTEGER,
+    char_end INTEGER,
+    page_number INTEGER,
+    snippet TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sections_paper_id ON sections (paper_id);
+CREATE INDEX IF NOT EXISTS idx_sections_paper_page ON sections (paper_id, page_number);
+
+-- Concepts extracted from papers
+CREATE TABLE IF NOT EXISTS concepts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    type TEXT,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_concepts_paper_id_name ON concepts (paper_id, lower(name));
+CREATE INDEX IF NOT EXISTS idx_concepts_type ON concepts (type);
+
+-- Relations link concepts within the context of a paper
+CREATE TABLE IF NOT EXISTS relations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    concept_id UUID NOT NULL REFERENCES concepts(id) ON DELETE CASCADE,
+    related_concept_id UUID REFERENCES concepts(id) ON DELETE SET NULL,
+    section_id UUID REFERENCES sections(id) ON DELETE SET NULL,
+    relation_type TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_relations_paper_id ON relations (paper_id);
+CREATE INDEX IF NOT EXISTS idx_relations_concept_id ON relations (concept_id);
+CREATE INDEX IF NOT EXISTS idx_relations_related_concept_id ON relations (related_concept_id);
+CREATE INDEX IF NOT EXISTS idx_relations_section_id ON relations (section_id);
+
+-- Evidence ties content back to vectors and relations for retrieval
+CREATE TABLE IF NOT EXISTS evidence (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    section_id UUID REFERENCES sections(id) ON DELETE SET NULL,
+    concept_id UUID REFERENCES concepts(id) ON DELETE SET NULL,
+    relation_id UUID REFERENCES relations(id) ON DELETE SET NULL,
+    snippet TEXT NOT NULL,
+    vector_id TEXT,
+    embedding_model TEXT,
+    score DOUBLE PRECISION,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_paper_id ON evidence (paper_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_section_id ON evidence (section_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_concept_id ON evidence (concept_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_relation_id ON evidence (relation_id);
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,11 @@ from fastapi.responses import JSONResponse
 from app.core.config import settings
 from app.db.database import test_postgres_connection
 from app.services.storage import ensure_bucket_exists
+from app.api.concepts import router as concepts_router
+from app.api.evidence import router as evidence_router
 from app.api.papers import router as papers_router
+from app.api.relations import router as relations_router
+from app.api.sections import router as sections_router
 from app.db.migrate import apply_migrations
 from app.db.pool import init_pool, close_pool, get_pool
 
@@ -79,6 +83,10 @@ def create_app() -> FastAPI:
 
     # Routers
     app.include_router(papers_router, prefix=settings.api_prefix)
+    app.include_router(sections_router, prefix=settings.api_prefix)
+    app.include_router(concepts_router, prefix=settings.api_prefix)
+    app.include_router(relations_router, prefix=settings.api_prefix)
+    app.include_router(evidence_router, prefix=settings.api_prefix)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,1 +1,25 @@
 
+from .concept import Concept, ConceptBase, ConceptCreate
+from .evidence import Evidence, EvidenceBase, EvidenceCreate
+from .paper import Paper, PaperBase, PaperCreate
+from .relation import Relation, RelationBase, RelationCreate
+from .section import Section, SectionBase, SectionCreate
+
+__all__ = [
+    "Paper",
+    "PaperBase",
+    "PaperCreate",
+    "Section",
+    "SectionBase",
+    "SectionCreate",
+    "Concept",
+    "ConceptBase",
+    "ConceptCreate",
+    "Relation",
+    "RelationBase",
+    "RelationCreate",
+    "Evidence",
+    "EvidenceBase",
+    "EvidenceCreate",
+]
+

--- a/backend/app/models/concept.py
+++ b/backend/app/models/concept.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ConceptBase(BaseModel):
+    name: str = Field(..., min_length=1)
+    type: Optional[str] = Field(default=None, max_length=128)
+    description: Optional[str] = None
+
+
+class ConceptCreate(ConceptBase):
+    paper_id: UUID
+
+
+class Concept(ConceptBase):
+    id: UUID
+    paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+

--- a/backend/app/models/evidence.py
+++ b/backend/app/models/evidence.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class EvidenceBase(BaseModel):
+    snippet: str = Field(..., min_length=1)
+    section_id: Optional[UUID] = None
+    concept_id: Optional[UUID] = None
+    relation_id: Optional[UUID] = None
+    vector_id: Optional[str] = Field(default=None, max_length=255)
+    embedding_model: Optional[str] = Field(default=None, max_length=255)
+    score: Optional[float] = None
+    metadata: Optional[dict[str, Any]] = None
+
+
+class EvidenceCreate(EvidenceBase):
+    paper_id: UUID
+
+
+class Evidence(EvidenceBase):
+    id: UUID
+    paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+

--- a/backend/app/models/relation.py
+++ b/backend/app/models/relation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class RelationBase(BaseModel):
+    relation_type: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    concept_id: Optional[UUID] = None
+    related_concept_id: Optional[UUID] = None
+    section_id: Optional[UUID] = None
+
+
+class RelationCreate(RelationBase):
+    paper_id: UUID
+
+
+class Relation(RelationBase):
+    id: UUID
+    paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+

--- a/backend/app/models/section.py
+++ b/backend/app/models/section.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SectionBase(BaseModel):
+    title: Optional[str] = Field(default=None, max_length=512)
+    content: str = Field(..., min_length=1)
+    char_start: Optional[int] = Field(default=None, ge=0)
+    char_end: Optional[int] = Field(default=None, ge=0)
+    page_number: Optional[int] = Field(default=None, ge=0)
+    snippet: Optional[str] = None
+
+
+class SectionCreate(SectionBase):
+    paper_id: UUID
+
+
+class Section(SectionBase):
+    id: UUID
+    paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+

--- a/backend/app/services/concepts.py
+++ b/backend/app/services/concepts.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.concept import Concept, ConceptCreate
+
+
+async def list_concepts(
+    paper_id: UUID,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+) -> List[Concept]:
+    pool = get_pool()
+    query = """
+        SELECT id, paper_id, name, type, description, created_at, updated_at
+        FROM concepts
+        WHERE paper_id = $1
+        ORDER BY name
+        LIMIT $2 OFFSET $3
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(query, paper_id, limit, offset)
+    return [Concept(**dict(row)) for row in rows]
+
+
+async def create_concept(data: ConceptCreate) -> Concept:
+    pool = get_pool()
+    query = """
+        INSERT INTO concepts (paper_id, name, type, description)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, paper_id, name, type, description, created_at, updated_at
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            query,
+            data.paper_id,
+            data.name,
+            data.type,
+            data.description,
+        )
+    return Concept(**dict(row))
+
+
+async def get_concept(concept_id: UUID) -> Optional[Concept]:
+    pool = get_pool()
+    query = """
+        SELECT id, paper_id, name, type, description, created_at, updated_at
+        FROM concepts
+        WHERE id = $1
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(query, concept_id)
+    return Concept(**dict(row)) if row else None
+

--- a/backend/app/services/evidence.py
+++ b/backend/app/services/evidence.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.evidence import Evidence, EvidenceCreate
+
+
+async def list_evidence(
+    paper_id: UUID,
+    *,
+    section_id: Optional[UUID] = None,
+    concept_id: Optional[UUID] = None,
+    relation_id: Optional[UUID] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> List[Evidence]:
+    pool = get_pool()
+    conditions = ["paper_id = $1"]
+    params: List[object] = [paper_id]
+    placeholder_index = 2
+
+    if section_id:
+        conditions.append(f"section_id = ${placeholder_index}")
+        params.append(section_id)
+        placeholder_index += 1
+    if concept_id:
+        conditions.append(f"concept_id = ${placeholder_index}")
+        params.append(concept_id)
+        placeholder_index += 1
+    if relation_id:
+        conditions.append(f"relation_id = ${placeholder_index}")
+        params.append(relation_id)
+        placeholder_index += 1
+
+    query = """
+        SELECT id, paper_id, section_id, concept_id, relation_id, snippet, vector_id, embedding_model, score, metadata, created_at, updated_at
+        FROM evidence
+        WHERE {conditions}
+        ORDER BY created_at DESC
+        LIMIT ${limit_idx} OFFSET ${offset_idx}
+    """.format(
+        conditions=" AND ".join(conditions),
+        limit_idx=placeholder_index,
+        offset_idx=placeholder_index + 1,
+    )
+    params.extend([limit, offset])
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(query, *params)
+    return [Evidence(**dict(row)) for row in rows]
+
+
+async def create_evidence(data: EvidenceCreate) -> Evidence:
+    pool = get_pool()
+    query = """
+        INSERT INTO evidence (paper_id, section_id, concept_id, relation_id, snippet, vector_id, embedding_model, score, metadata)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        RETURNING id, paper_id, section_id, concept_id, relation_id, snippet, vector_id, embedding_model, score, metadata, created_at, updated_at
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            query,
+            data.paper_id,
+            data.section_id,
+            data.concept_id,
+            data.relation_id,
+            data.snippet,
+            data.vector_id,
+            data.embedding_model,
+            data.score,
+            data.metadata,
+        )
+    return Evidence(**dict(row))
+
+
+async def get_evidence(evidence_id: UUID) -> Optional[Evidence]:
+    pool = get_pool()
+    query = """
+        SELECT id, paper_id, section_id, concept_id, relation_id, snippet, vector_id, embedding_model, score, metadata, created_at, updated_at
+        FROM evidence
+        WHERE id = $1
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(query, evidence_id)
+    return Evidence(**dict(row)) if row else None
+

--- a/backend/app/services/relations.py
+++ b/backend/app/services/relations.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.relation import Relation, RelationCreate
+
+
+async def list_relations(
+    paper_id: UUID,
+    *,
+    concept_id: Optional[UUID] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> List[Relation]:
+    pool = get_pool()
+    base_query = """
+        SELECT id, paper_id, concept_id, related_concept_id, section_id, relation_type, description, created_at, updated_at
+        FROM relations
+        WHERE paper_id = $1
+    """
+    params: List[object] = [paper_id]
+    if concept_id:
+        base_query += " AND concept_id = $2"
+        params.append(concept_id)
+    base_query += " ORDER BY created_at DESC LIMIT $%d OFFSET $%d" % (len(params) + 1, len(params) + 2)
+    params.extend([limit, offset])
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(base_query, *params)
+    return [Relation(**dict(row)) for row in rows]
+
+
+async def create_relation(data: RelationCreate) -> Relation:
+    pool = get_pool()
+    query = """
+        INSERT INTO relations (paper_id, concept_id, related_concept_id, section_id, relation_type, description)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, paper_id, concept_id, related_concept_id, section_id, relation_type, description, created_at, updated_at
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            query,
+            data.paper_id,
+            data.concept_id,
+            data.related_concept_id,
+            data.section_id,
+            data.relation_type,
+            data.description,
+        )
+    return Relation(**dict(row))
+
+
+async def get_relation(relation_id: UUID) -> Optional[Relation]:
+    pool = get_pool()
+    query = """
+        SELECT id, paper_id, concept_id, related_concept_id, section_id, relation_type, description, created_at, updated_at
+        FROM relations
+        WHERE id = $1
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(query, relation_id)
+    return Relation(**dict(row)) if row else None
+

--- a/backend/app/services/sections.py
+++ b/backend/app/services/sections.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.section import Section, SectionCreate
+
+
+async def list_sections(
+    paper_id: UUID,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+) -> List[Section]:
+    pool = get_pool()
+    query = """
+        SELECT id, paper_id, title, content, char_start, char_end, page_number, snippet, created_at, updated_at
+        FROM sections
+        WHERE paper_id = $1
+        ORDER BY page_number NULLS LAST, char_start NULLS LAST, created_at
+        LIMIT $2 OFFSET $3
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(query, paper_id, limit, offset)
+    return [Section(**dict(row)) for row in rows]
+
+
+async def create_section(data: SectionCreate) -> Section:
+    pool = get_pool()
+    query = """
+        INSERT INTO sections (paper_id, title, content, char_start, char_end, page_number, snippet)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING id, paper_id, title, content, char_start, char_end, page_number, snippet, created_at, updated_at
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            query,
+            data.paper_id,
+            data.title,
+            data.content,
+            data.char_start,
+            data.char_end,
+            data.page_number,
+            data.snippet,
+        )
+    return Section(**dict(row))
+
+
+async def get_section(section_id: UUID) -> Optional[Section]:
+    pool = get_pool()
+    query = """
+        SELECT id, paper_id, title, content, char_start, char_end, page_number, snippet, created_at, updated_at
+        FROM sections
+        WHERE id = $1
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(query, section_id)
+    return Section(**dict(row)) if row else None
+


### PR DESCRIPTION
## Summary
- add Pydantic models for sections, concepts, relations, and evidence
- create a database migration defining tables and indexes for the new entities
- implement async services and FastAPI routers for creating and reading graph entities

## Testing
- python -m compileall backend/app
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc5526dcd48321a0846e54b40721ed