### PR TITLE
Add dashboard layout scaffolding

### DIFF
--- a/Frontend/app/globals.css
+++ b/Frontend/app/globals.css
@@ -1,0 +1,58 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --radius: 0.75rem;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 84% 4.9%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 84% 4.9%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 212.7 26.8% 83.9%;
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
+}

--- a/Frontend/app/layout.tsx
+++ b/Frontend/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+import Header from "../components/header";
+import Sidebar from "../components/sidebar";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "SciNets Dashboard",
+  description: "Operational console for the SciNets research knowledge graph.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} min-h-screen bg-background text-foreground antialiased`}>
+        <div className="flex min-h-screen w-full bg-muted/10">
+          <Sidebar />
+          <div className="flex flex-1 flex-col">
+            <Header />
+            <main className="flex-1 overflow-y-auto bg-background p-6">{children}</main>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -1,9 +1,157 @@
+import {
+  Activity,
+  Database,
+  FileText,
+  LineChart,
+  Users,
+} from "lucide-react";
+
+const stats = [
+  {
+    title: "Knowledge Graph Nodes",
+    value: "18,245",
+    change: "+3.4% vs last week",
+    icon: Database,
+  },
+  {
+    title: "Published Papers",
+    value: "612",
+    change: "+28 new",
+    icon: FileText,
+  },
+  {
+    title: "Collaborating Researchers",
+    value: "134",
+    change: "+12 active this month",
+    icon: Users,
+  },
+  {
+    title: "Pipeline Health",
+    value: "Stable",
+    change: "Last run 2 hours ago",
+    icon: Activity,
+  },
+];
+
+const activityFeed = [
+  {
+    title: "Ingestion completed",
+    description: "ArXiv computer vision papers batch",
+    time: "10 minutes ago",
+  },
+  {
+    title: "Dataset validated",
+    description: "Protein folding simulation set",
+    time: "45 minutes ago",
+  },
+  {
+    title: "New collaborator joined",
+    description: "Dr. Li Wei added to Quantum Materials project",
+    time: "2 hours ago",
+  },
+];
+
 export default function Home() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">Scinets Frontend</h1>
-      <p className="mt-2 text-gray-600">Infrastructure up. Backend health at /health.</p>
-    </main>
+    <div className="space-y-6">
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {stats.map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <div
+              key={stat.title}
+              className="rounded-lg border bg-card p-5 shadow-sm transition hover:shadow-md"
+            >
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground">{stat.title}</p>
+                  <p className="mt-2 text-2xl font-semibold text-foreground">{stat.value}</p>
+                </div>
+                <span className="rounded-md bg-primary/10 p-2 text-primary">
+                  <Icon className="h-5 w-5" />
+                </span>
+              </div>
+              <p className="mt-4 text-xs font-medium uppercase tracking-wide text-primary">
+                {stat.change}
+              </p>
+            </div>
+          );
+        })}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Ingestion Pipeline</h2>
+              <p className="text-sm text-muted-foreground">Track the latest crawl and enrichment jobs.</p>
+            </div>
+            <LineChart className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <div className="mt-6 space-y-5">
+            <div>
+              <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                <span>Metadata aggregation</span>
+                <span className="text-muted-foreground">82%</span>
+              </div>
+              <div className="mt-2 h-2 rounded-full bg-muted">
+                <div className="h-2 rounded-full bg-primary" style={{ width: "82%" }} />
+              </div>
+            </div>
+            <div>
+              <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                <span>Entity resolution</span>
+                <span className="text-muted-foreground">64%</span>
+              </div>
+              <div className="mt-2 h-2 rounded-full bg-muted">
+                <div className="h-2 rounded-full bg-primary/70" style={{ width: "64%" }} />
+              </div>
+            </div>
+            <div>
+              <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                <span>Graph sync</span>
+                <span className="text-muted-foreground">Next run: 03:00 UTC</span>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Automated refresh scheduled overnight to capture newly published research.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-foreground">Recent activity</h2>
+            <ul className="mt-4 space-y-4">
+              {activityFeed.map((item) => (
+                <li key={item.title} className="border-l-2 border-primary/30 pl-4">
+                  <p className="text-sm font-semibold text-foreground">{item.title}</p>
+                  <p className="text-sm text-muted-foreground">{item.description}</p>
+                  <p className="text-xs text-muted-foreground">{item.time}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-foreground">Action items</h2>
+            <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
+              <li className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
+                Review entity merges proposed for AI Safety papers.
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-amber-400" aria-hidden />
+                Approve dataset sync for Materials Project updates.
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-sky-400" aria-hidden />
+                Invite collaborators from the National Lab workspace.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }
-

--- a/Frontend/components/header.tsx
+++ b/Frontend/components/header.tsx
@@ -1,0 +1,34 @@
+import { Bell, Search } from "lucide-react";
+
+const Header = () => {
+  return (
+    <header className="flex items-center border-b bg-card/80 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Dashboard</p>
+        <h1 className="text-lg font-semibold text-foreground">SciNets Overview</h1>
+      </div>
+      <div className="ml-auto flex items-center gap-4">
+        <div className="relative hidden md:block">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="search"
+            placeholder="Search papers, datasets, people..."
+            className="w-64 rounded-md border border-input bg-background px-3 py-2 pl-9 text-sm shadow-sm outline-none transition focus:border-transparent focus:ring-2 focus:ring-primary/40"
+          />
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-input bg-background text-muted-foreground transition hover:text-foreground"
+          aria-label="View notifications"
+        >
+          <Bell className="h-4 w-4" />
+        </button>
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold uppercase text-primary">
+          SN
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/Frontend/components/sidebar.tsx
+++ b/Frontend/components/sidebar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Database,
+  FileText,
+  LayoutDashboard,
+  Settings,
+  UploadCloud,
+} from "lucide-react";
+
+const navigation = [
+  { name: "Overview", href: "/", icon: LayoutDashboard },
+  { name: "Datasets", href: "/datasets", icon: Database },
+  { name: "Papers", href: "/papers", icon: FileText },
+  { name: "Ingestion", href: "/ingestion", icon: UploadCloud },
+  { name: "Settings", href: "/settings", icon: Settings },
+];
+
+const Sidebar = () => {
+  const pathname = usePathname();
+
+  return (
+    <aside className="hidden min-h-screen w-64 flex-col border-r bg-card/60 pb-6 pt-8 shadow-sm md:flex">
+      <div className="px-6">
+        <div className="text-sm font-semibold uppercase tracking-[0.2em] text-primary">SciNets</div>
+        <p className="mt-2 text-sm font-medium text-foreground">Knowledge Graph</p>
+        <p className="text-xs text-muted-foreground">Manage research entities, pipelines, and integrations.</p>
+      </div>
+      <nav className="mt-8 flex flex-1 flex-col gap-1 px-3" aria-label="Primary navigation">
+        {navigation.map((item) => {
+          const Icon = item.icon;
+          const isActive =
+            pathname === item.href || (item.href !== "/" && pathname?.startsWith(`${item.href}/`));
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-muted ${
+                isActive ? "bg-muted text-foreground shadow-sm" : "text-muted-foreground"
+              }`}
+              aria-current={isActive ? "page" : undefined}
+            >
+              <Icon className="h-4 w-4" />
+              <span>{item.name}</span>
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="mt-auto px-6">
+        <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4 text-xs text-muted-foreground">
+          <p className="font-semibold text-foreground">Need more integrations?</p>
+          <p>Connect additional sources to keep the knowledge graph fresh.</p>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
## Summary
- add shared Tailwind tokens and root layout that wraps pages with the new chrome
- implement header and sidebar components that provide navigation for the dashboard
- replace the home page placeholder with an overview dashboard scaffold

## Testing
- npm run lint *(fails: prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc55940d648321adf6f62eed3fcd6a