### PR TITLE
Add PostCSS config for Tailwind

### DIFF
--- a/Frontend/postcss.config.js
+++ b/Frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- add a PostCSS configuration so Next.js loads Tailwind CSS and autoprefixer plugins

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cc66e4ae5083219cdbad210a04590d