### PR TITLE
Add paper upload and download support

### DIFF
--- a/backend/app/api/papers.py
+++ b/backend/app/api/papers.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Query, UploadFile
 
 from app.models.paper import Paper, PaperCreate
 from app.services.papers import create_paper, get_paper, list_papers
+from app.services.storage import create_presigned_download_url, upload_pdf_to_storage
+from app.services.tasks import parse_pdf_task
 
 
 router = APIRouter(prefix="/papers", tags=["papers"])
@@ -34,4 +37,67 @@ async def api_get_paper(paper_id: UUID):
     if not paper:
         raise HTTPException(status_code=404, detail="Paper not found")
     return paper
+
+
+@router.post("/upload", response_model=Paper, status_code=201)
+async def api_upload_paper(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(..., description="PDF file to upload"),
+    title: Optional[str] = Form(default=None),
+    authors: Optional[str] = Form(default=None),
+    venue: Optional[str] = Form(default=None),
+    year: Optional[int] = Form(default=None),
+):
+    try:
+        stored = await upload_pdf_to_storage(file)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    derived_title = title or Path(stored.file_name).stem or "Untitled"
+
+    paper = await create_paper(
+        PaperCreate(
+            title=derived_title,
+            authors=authors,
+            venue=venue,
+            year=year,
+            status="uploaded",
+            file_path=stored.object_name,
+            file_name=stored.file_name,
+            file_size=stored.size,
+            file_content_type=stored.content_type,
+        )
+    )
+
+    background_tasks.add_task(parse_pdf_task, paper.id)
+
+    return paper
+
+
+@router.get("/{paper_id}/download")
+async def api_download_paper(
+    paper_id: UUID,
+    expires_in: int = Query(
+        default=3600,
+        ge=60,
+        le=24 * 3600,
+        description="Signed URL validity in seconds (min 60, max 86400).",
+    ),
+):
+    paper = await get_paper(paper_id)
+    if not paper:
+        raise HTTPException(status_code=404, detail="Paper not found")
+    if not paper.file_path:
+        raise HTTPException(status_code=404, detail="Paper does not have an uploaded file")
+
+    try:
+        download_url = create_presigned_download_url(paper.file_path, expires_in=expires_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return {"download_url": download_url, "expires_in": expires_in}
 

--- a/backend/app/db/migrations/0003_paper_files.sql
+++ b/backend/app/db/migrations/0003_paper_files.sql
@@ -1,0 +1,7 @@
+ALTER TABLE papers
+    ADD COLUMN IF NOT EXISTS file_path TEXT,
+    ADD COLUMN IF NOT EXISTS file_name TEXT,
+    ADD COLUMN IF NOT EXISTS file_size BIGINT,
+    ADD COLUMN IF NOT EXISTS file_content_type TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_papers_file_path ON papers (file_path);

--- a/backend/app/models/paper.py
+++ b/backend/app/models/paper.py
@@ -12,6 +12,10 @@ class PaperBase(BaseModel):
     authors: Optional[str] = None
     venue: Optional[str] = None
     year: Optional[int] = Field(default=None, ge=1800, le=2100)
+    file_path: Optional[str] = None
+    file_name: Optional[str] = None
+    file_size: Optional[int] = Field(default=None, ge=0)
+    file_content_type: Optional[str] = None
 
 
 class PaperCreate(PaperBase):

--- a/backend/app/services/papers.py
+++ b/backend/app/services/papers.py
@@ -7,18 +7,23 @@ from app.db.pool import get_pool
 from app.models.paper import Paper, PaperCreate
 
 
+PAPER_COLUMNS = (
+    "id, title, authors, venue, year, status, file_path, file_name, file_size, "
+    "file_content_type, created_at, updated_at"
+)
+
+
 async def list_papers(limit: int = 50, offset: int = 0, q: Optional[str] = None) -> List[Paper]:
     pool = get_pool()
-    query = "SELECT id, title, authors, venue, year, status, created_at, updated_at FROM papers"
+    query = f"SELECT {PAPER_COLUMNS} FROM papers"
     params: list[Any] = []
+    param_idx = 1
     if q:
-        query += " WHERE title ILIKE $1"
+        query += f" WHERE title ILIKE ${param_idx}"
         params.append(f"%{q}%")
-    query += " ORDER BY created_at DESC LIMIT $2 OFFSET $3" if q else " ORDER BY created_at DESC LIMIT $1 OFFSET $2"
-    if q:
-        params.extend([limit, offset])
-    else:
-        params.extend([limit, offset])
+        param_idx += 1
+    query += f" ORDER BY created_at DESC LIMIT ${param_idx} OFFSET ${param_idx + 1}"
+    params.extend([limit, offset])
     async with pool.acquire() as conn:
         rows = await conn.fetch(query, *params)
     return [Paper(**dict(row)) for row in rows]
@@ -29,15 +34,51 @@ async def create_paper(data: PaperCreate) -> Paper:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            INSERT INTO papers (title, authors, venue, year, status)
-            VALUES ($1, $2, $3, $4, COALESCE($5, 'uploaded'))
-            RETURNING id, title, authors, venue, year, status, created_at, updated_at
+            INSERT INTO papers (
+                title,
+                authors,
+                venue,
+                year,
+                status,
+                file_path,
+                file_name,
+                file_size,
+                file_content_type
+            )
+            VALUES (
+                $1,
+                $2,
+                $3,
+                $4,
+                COALESCE($5, 'uploaded'),
+                $6,
+                $7,
+                $8,
+                $9
+            )
+            RETURNING
+                id,
+                title,
+                authors,
+                venue,
+                year,
+                status,
+                file_path,
+                file_name,
+                file_size,
+                file_content_type,
+                created_at,
+                updated_at
             """,
             data.title,
             data.authors,
             data.venue,
             data.year,
             data.status,
+            data.file_path,
+            data.file_name,
+            data.file_size,
+            data.file_content_type,
         )
     return Paper(**dict(row))
 
@@ -46,7 +87,7 @@ async def get_paper(paper_id: UUID) -> Optional[Paper]:
     pool = get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT id, title, authors, venue, year, status, created_at, updated_at FROM papers WHERE id=$1",
+            f"SELECT {PAPER_COLUMNS} FROM papers WHERE id=$1",
             paper_id,
         )
     return Paper(**dict(row)) if row else None

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
+import io
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Final
+from uuid import uuid4
+
+from fastapi import UploadFile
 from minio import Minio
 from minio.error import S3Error
 
 from app.core.config import settings
+
+
+PDF_CONTENT_TYPES: Final[set[str]] = {"application/pdf"}
+MAX_FILE_SIZE_BYTES: Final[int] = 50 * 1024 * 1024  # 50 MB limit for MVP
+
+
+@dataclass
+class StorageUploadResult:
+    bucket: str
+    object_name: str
+    file_name: str
+    size: int
+    content_type: str
 
 
 def get_minio_client() -> Minio:
@@ -26,4 +47,83 @@ def ensure_bucket_exists(bucket_name: str) -> None:
     exists = client.bucket_exists(bucket_name)
     if not exists:
         client.make_bucket(bucket_name)
+
+
+async def upload_pdf_to_storage(file: UploadFile) -> StorageUploadResult:
+    if not file.filename:
+        raise ValueError("Uploaded file must include a filename")
+
+    if not _is_pdf(file):
+        raise ValueError("Only PDF uploads are supported")
+
+    data = await file.read()
+    size = len(data)
+    if size == 0:
+        raise ValueError("Uploaded file is empty")
+    if size > MAX_FILE_SIZE_BYTES:
+        raise ValueError("Uploaded file exceeds maximum allowed size")
+
+    client = get_minio_client()
+    bucket = settings.minio_bucket_papers
+    object_name = _build_object_name(file.filename)
+    file_name = Path(file.filename).name
+
+    content_type = _resolve_content_type(file)
+
+    try:
+        client.put_object(
+            bucket_name=bucket,
+            object_name=object_name,
+            data=io.BytesIO(data),
+            length=size,
+            content_type=content_type,
+        )
+    except S3Error as exc:  # pragma: no cover - external dependency behaviour
+        raise RuntimeError(f"Failed to store file in MinIO: {exc}") from exc
+    finally:
+        await file.close()
+
+    return StorageUploadResult(
+        bucket=bucket,
+        object_name=object_name,
+        file_name=file_name,
+        size=size,
+        content_type=content_type,
+    )
+
+
+def create_presigned_download_url(object_name: str, expires_in: int = 3600) -> str:
+    if expires_in <= 0:
+        raise ValueError("expires_in must be a positive integer")
+
+    client = get_minio_client()
+    try:
+        return client.presigned_get_object(
+            bucket_name=settings.minio_bucket_papers,
+            object_name=object_name,
+            expires=timedelta(seconds=expires_in),
+        )
+    except S3Error as exc:  # pragma: no cover - external dependency behaviour
+        raise RuntimeError(f"Failed to generate download URL: {exc}") from exc
+
+
+def _is_pdf(file: UploadFile) -> bool:
+    content_type = (file.content_type or "").lower()
+    if content_type in PDF_CONTENT_TYPES:
+        return True
+    filename = (file.filename or "").lower()
+    return filename.endswith(".pdf")
+
+
+def _build_object_name(filename: str) -> str:
+    clean_name = Path(filename).name.replace(" ", "_")
+    unique_prefix = uuid4().hex
+    return f"{unique_prefix}/{clean_name}"
+
+
+def _resolve_content_type(file: UploadFile) -> str:
+    content_type = (file.content_type or "application/pdf").lower()
+    if content_type not in PDF_CONTENT_TYPES:
+        return "application/pdf"
+    return content_type
 

--- a/backend/app/services/tasks.py
+++ b/backend/app/services/tasks.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+
+def parse_pdf_task(paper_id: UUID) -> None:
+    """Placeholder task hook for triggering the PDF parsing pipeline.
+
+    For the MVP we simply log the invocation. In future iterations this will
+    enqueue a background job (Celery/Arq/etc.) that performs extraction and
+    updates the paper status.
+    """
+
+    print(f"[parse_pdf_task] Triggered for paper {paper_id}")


### PR DESCRIPTION
## Summary
- add migration and model fields for storing uploaded paper file metadata
- implement MinIO upload helper and presigned download utility
- expose /api/papers/upload and /api/papers/{id}/download endpoints and trigger the parse task hook

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68cc6852512483218f7445d52d62a82e