### PR TITLE
Add semantic search service and frontend integration

### DIFF
--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -6,6 +6,8 @@ import {
   Users,
 } from "lucide-react";
 
+import SemanticSearch from "../components/semantic-search";
+
 const stats = [
   {
     title: "Knowledge Graph Nodes",
@@ -54,6 +56,8 @@ const activityFeed = [
 export default function Home() {
   return (
     <div className="space-y-6">
+      <SemanticSearch />
+
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         {stats.map((stat) => {
           const Icon = stat.icon;

--- a/Frontend/components/semantic-search.tsx
+++ b/Frontend/components/semantic-search.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { FormEvent, useCallback, useMemo, useState } from "react";
+import axios from "axios";
+import { AlertCircle, FileText, Loader2, Search } from "lucide-react";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const MAX_RESULTS = 8;
+
+type SemanticSearchResult = {
+  paper_id: string;
+  section_id?: string | null;
+  section_title?: string | null;
+  snippet: string;
+  score: number;
+  page_number?: number | null;
+  char_start?: number | null;
+  char_end?: number | null;
+};
+
+const getErrorMessage = (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    const detail = error.response?.data?.detail;
+    if (typeof detail === "string" && detail.trim().length > 0) {
+      return detail;
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Unexpected error while performing semantic search.";
+};
+
+const formatScore = (value: number) => {
+  const normalized = Number.isFinite(value) ? Math.max(-1, Math.min(1, value)) : 0;
+  const percentage = Math.round(((normalized + 1) / 2) * 100);
+  return `${percentage}% match`;
+};
+
+const formatOffsets = (start?: number | null, end?: number | null) => {
+  if (typeof start === "number" && typeof end === "number") {
+    return `${start.toLocaleString()} – ${end.toLocaleString()}`;
+  }
+  return null;
+};
+
+const truncateId = (value: string) => {
+  if (value.length <= 12) {
+    return value;
+  }
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+};
+
+const SemanticSearch = () => {
+  const [query, setQuery] = useState("");
+  const [activeQuery, setActiveQuery] = useState("");
+  const [results, setResults] = useState<SemanticSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasResults = results.length > 0;
+
+  const hint = useMemo(() => {
+    if (isSearching) {
+      return `Searching for “${activeQuery}”...`;
+    }
+    if (!activeQuery) {
+      return "Ask a question about your corpus to surface relevant sections.";
+    }
+    if (error) {
+      return null;
+    }
+    if (!hasResults) {
+      return `No results for “${activeQuery}”. Try refining your question.`;
+    }
+    return `Top matches for “${activeQuery}”.`;
+  }, [activeQuery, error, hasResults, isSearching]);
+
+  const performSearch = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      setActiveQuery(trimmed);
+
+      if (!trimmed) {
+        setResults([]);
+        setError(null);
+        return;
+      }
+
+      setIsSearching(true);
+      try {
+        const response = await axios.get<SemanticSearchResult[]>(
+          `${API_BASE_URL}/api/search/similarity`,
+          {
+            params: { q: trimmed, limit: MAX_RESULTS },
+          }
+        );
+        setResults(response.data);
+        setError(null);
+      } catch (err) {
+        setResults([]);
+        setError(getErrorMessage(err));
+      } finally {
+        setIsSearching(false);
+      }
+    },
+    []
+  );
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void performSearch(query);
+    },
+    [performSearch, query]
+  );
+
+  const handleReset = useCallback(() => {
+    setQuery("");
+    setActiveQuery("");
+    setResults([]);
+    setError(null);
+  }, []);
+
+  return (
+    <section className="rounded-lg border bg-card p-6 shadow-sm">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Search className="h-4 w-4" />
+          </span>
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Semantic search</h2>
+            {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
+          </div>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Ask about findings, methods, or datasets..."
+            className="w-full rounded-md border border-input bg-background px-3 py-2 pl-9 text-sm shadow-sm outline-none transition focus:border-transparent focus:ring-2 focus:ring-primary/40"
+          />
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-70"
+            disabled={isSearching}
+          >
+            {isSearching ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Searching
+              </span>
+            ) : (
+              "Search"
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-70"
+            disabled={isSearching}
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <div className="mt-4 flex items-start gap-2 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">
+          <AlertCircle className="mt-0.5 h-4 w-4" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="mt-5 space-y-4">
+        {isSearching && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Fetching semantic matches…
+          </div>
+        )}
+
+        {!isSearching && hasResults && (
+          <ul className="space-y-4">
+            {results.map((item, index) => {
+              const offset = formatOffsets(item.char_start, item.char_end);
+              const key = item.section_id ?? `${item.paper_id}-${index}`;
+              return (
+                <li
+                  key={key}
+                  className="rounded-md border bg-background/60 p-4 shadow-sm transition hover:bg-background"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                      <FileText className="h-4 w-4 text-primary" />
+                      <span>{item.section_title?.trim() || "Untitled section"}</span>
+                    </div>
+                    <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+                      {formatScore(item.score)}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{item.snippet}</p>
+                  <dl className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+                    {item.page_number != null && (
+                      <div className="flex items-center gap-1">
+                        <dt className="font-medium text-foreground">Page</dt>
+                        <dd>{item.page_number}</dd>
+                      </div>
+                    )}
+                    {offset && (
+                      <div className="flex items-center gap-1">
+                        <dt className="font-medium text-foreground">Offsets</dt>
+                        <dd>{offset}</dd>
+                      </div>
+                    )}
+                    <div className="flex items-center gap-1">
+                      <dt className="font-medium text-foreground">Paper</dt>
+                      <dd className="font-mono text-[11px] text-muted-foreground/80">
+                        {truncateId(item.paper_id)}
+                      </dd>
+                    </div>
+                  </dl>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {!isSearching && !hasResults && !error && activeQuery && (
+          <p className="text-sm text-muted-foreground">
+            No semantic matches yet. Consider broadening your question or trying alternative terminology.
+          </p>
+        )}
+
+        {!isSearching && !activeQuery && !error && (
+          <p className="text-sm text-muted-foreground">
+            Tip: Ask targeted questions like “How do graph neural networks model protein folding?”
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default SemanticSearch;

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.search import SearchResult
+from app.services.search import (
+    VectorStoreNotAvailableError,
+    get_search_service,
+)
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+@router.get("/similarity", response_model=List[SearchResult])
+async def api_similarity_search(
+    q: str = Query(..., description="Free-text search query"),
+    limit: int = Query(default=5, ge=1, le=20, description="Maximum number of results"),
+) -> List[SearchResult]:
+    service = get_search_service()
+    try:
+        return await service.search(query=q, limit=limit)
+    except VectorStoreNotAvailableError as exc:
+        raise HTTPException(status_code=503, detail=f"Vector store unavailable: {exc}") from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.concepts import router as concepts_router
 from app.api.evidence import router as evidence_router
 from app.api.papers import router as papers_router
 from app.api.relations import router as relations_router
+from app.api.search import router as search_router
 from app.api.sections import router as sections_router
 from app.db.migrate import apply_migrations
 from app.db.pool import init_pool, close_pool, get_pool
@@ -87,6 +88,7 @@ def create_app() -> FastAPI:
     app.include_router(concepts_router, prefix=settings.api_prefix)
     app.include_router(relations_router, prefix=settings.api_prefix)
     app.include_router(evidence_router, prefix=settings.api_prefix)
+    app.include_router(search_router, prefix=settings.api_prefix)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from .evidence import Evidence, EvidenceBase, EvidenceCreate
 from .paper import Paper, PaperBase, PaperCreate
 from .relation import Relation, RelationBase, RelationCreate
 from .section import Section, SectionBase, SectionCreate
+from .search import SearchResult
 
 __all__ = [
     "Paper",
@@ -21,5 +22,6 @@ __all__ = [
     "Evidence",
     "EvidenceBase",
     "EvidenceCreate",
+    "SearchResult",
 ]
 

--- a/backend/app/models/search.py
+++ b/backend/app/models/search.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SearchResult(BaseModel):
+    paper_id: UUID
+    section_id: Optional[UUID] = None
+    section_title: Optional[str] = Field(default=None, max_length=500)
+    snippet: str = Field(..., min_length=1)
+    score: float
+    page_number: Optional[int] = None
+    char_start: Optional[int] = None
+    char_end: Optional[int] = None
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from app.core.config import settings
+from app.models.search import SearchResult
+from app.services.embeddings import (
+    EmbeddingBackend,
+    VectorSearchResult,
+    VectorStore,
+    VectorStoreNotAvailableError,
+    build_embedding_backend,
+)
+
+_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
+_DEFAULT_MAX_LIMIT = 20
+
+
+@dataclass
+class _RankedMatch:
+    vector_id: str
+    payload: dict[str, object]
+    base_score: float
+    lexical_score: float
+    final_score: float
+
+
+def _tokenize(text: str) -> set[str]:
+    return {token for token in _TOKEN_PATTERN.findall(text.lower()) if token}
+
+
+def _lexical_similarity(query: str, text: str) -> float:
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return 0.0
+    text_tokens = _tokenize(text)
+    if not text_tokens:
+        return 0.0
+    overlap = len(query_tokens & text_tokens)
+    if overlap == 0:
+        return 0.0
+    return overlap / float(len(query_tokens))
+
+
+class SemanticSearchService:
+    def __init__(
+        self,
+        *,
+        backend: EmbeddingBackend | None = None,
+        vector_store: VectorStore | None = None,
+        rerank_top_k: int = 3,
+        lexical_weight: float = 0.3,
+        max_limit: int = _DEFAULT_MAX_LIMIT,
+    ) -> None:
+        self._model_name = settings.embedding_model_name
+        self._dimension = max(1, settings.embedding_dimension)
+        self._batch_size = max(1, settings.embedding_batch_size)
+        self._backend = backend or build_embedding_backend(
+            self._model_name, self._dimension
+        )
+        self._vector_store = vector_store or VectorStore(
+            settings.qdrant_collection_name, self._dimension
+        )
+        self._rerank_top_k = max(0, rerank_top_k)
+        self._lexical_weight = float(min(max(lexical_weight, 0.0), 1.0))
+        self._max_limit = max(1, max_limit)
+
+    async def search(self, *, query: str, limit: int = 5) -> List[SearchResult]:
+        normalized = query.strip()
+        if not normalized:
+            return []
+
+        limit = max(1, min(limit, self._max_limit))
+
+        embeddings = await self._backend.embed([normalized], self._batch_size)
+        if not embeddings:
+            return []
+        vector = list(map(float, embeddings[0]))
+        if not vector:
+            return []
+
+        search_limit = max(limit, self._rerank_top_k)
+        raw_results = await self._vector_store.search(vector, search_limit)
+        if not raw_results:
+            return []
+
+        ranked = self._rank_results(normalized, raw_results)
+        if not ranked:
+            return []
+
+        top_results = ranked[:limit]
+        return [self._build_result(match) for match in top_results if match is not None]
+
+    def _rank_results(
+        self, query: str, results: Sequence[VectorSearchResult]
+    ) -> List[_RankedMatch]:
+        ranked: List[_RankedMatch] = []
+        for result in results:
+            payload = dict(result.payload)
+            snippet = self._extract_snippet(payload)
+            lexical_score = _lexical_similarity(query, snippet)
+            final_score = self._combine_scores(result.score, lexical_score)
+            ranked.append(
+                _RankedMatch(
+                    vector_id=result.vector_id,
+                    payload=payload,
+                    base_score=float(result.score),
+                    lexical_score=lexical_score,
+                    final_score=final_score,
+                )
+            )
+
+        if not ranked:
+            return []
+
+        rerank_count = min(self._rerank_top_k, len(ranked))
+        if rerank_count:
+            head = sorted(
+                ranked[:rerank_count],
+                key=lambda item: item.final_score,
+                reverse=True,
+            )
+            tail = ranked[rerank_count:]
+            return head + tail
+        return ranked
+
+    def _combine_scores(self, base: float, lexical: float) -> float:
+        base_clamped = max(-1.0, min(1.0, float(base)))
+        lexical_clamped = max(0.0, min(1.0, float(lexical)))
+        weight = self._lexical_weight
+        return (1.0 - weight) * base_clamped + weight * lexical_clamped
+
+    def _extract_snippet(self, payload: dict[str, object]) -> str:
+        snippet = payload.get("snippet")
+        if isinstance(snippet, str) and snippet.strip():
+            return snippet
+        content = payload.get("content")
+        if isinstance(content, str):
+            cleaned = content.strip()
+            if cleaned:
+                return cleaned
+        return ""
+
+    def _build_result(self, match: _RankedMatch) -> SearchResult | None:
+        paper_id = match.payload.get("paper_id")
+        snippet = self._extract_snippet(match.payload)
+        if not snippet or not paper_id:
+            return None
+        section_title = match.payload.get("section_title")
+        if section_title is not None and not isinstance(section_title, str):
+            section_title = str(section_title)
+        return SearchResult(
+            paper_id=paper_id,
+            section_id=match.payload.get("section_id"),
+            section_title=section_title,
+            snippet=snippet,
+            score=float(match.final_score),
+            page_number=match.payload.get("page_number"),
+            char_start=match.payload.get("char_start"),
+            char_end=match.payload.get("char_end"),
+        )
+
+
+_service: SemanticSearchService | None = None
+_service_lock = threading.Lock()
+
+
+def get_search_service() -> SemanticSearchService:
+    global _service
+    if _service is None:
+        with _service_lock:
+            if _service is None:
+                _service = SemanticSearchService()
+    return _service
+
+
+__all__ = [
+    "SemanticSearchService",
+    "get_search_service",
+    "VectorStoreNotAvailableError",
+]

--- a/backend/tests/test_search_api.py
+++ b/backend/tests/test_search_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.search import api_similarity_search
+from app.models.search import SearchResult
+from app.services.search import VectorStoreNotAvailableError
+
+
+class FakeSearchService:
+    def __init__(self, results: list[SearchResult]) -> None:
+        self._results = results
+        self.calls: list[tuple[str, int]] = []
+
+    async def search(self, *, query: str, limit: int) -> list[SearchResult]:
+        self.calls.append((query, limit))
+        return list(self._results)
+
+
+class ErrorSearchService:
+    async def search(self, *, query: str, limit: int) -> list[SearchResult]:
+        raise VectorStoreNotAvailableError("offline")
+
+
+def test_api_similarity_search_returns_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_api_similarity_search_returns_results(monkeypatch))
+
+
+async def _run_api_similarity_search_returns_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    paper_id = uuid4()
+    section_id = uuid4()
+    expected = SearchResult(
+        paper_id=paper_id,
+        section_id=section_id,
+        snippet="Coherent search results snippet.",
+        score=0.88,
+        page_number=4,
+        char_start=5,
+        char_end=64,
+    )
+
+    service = FakeSearchService([expected])
+    monkeypatch.setattr("app.api.search.get_search_service", lambda: service)
+
+    results = await api_similarity_search(q="coherent", limit=5)
+
+    assert results == [expected]
+    assert service.calls == [("coherent", 5)]
+
+
+def test_api_similarity_search_maps_vector_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_api_similarity_search_maps_vector_errors(monkeypatch))
+
+
+async def _run_api_similarity_search_maps_vector_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.api.search.get_search_service", lambda: ErrorSearchService())
+
+    with pytest.raises(HTTPException) as exc:
+        await api_similarity_search(q="unstable", limit=3)
+
+    assert exc.value.status_code == 503
+    assert "Vector store unavailable" in str(exc.value.detail)

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.models.search import SearchResult
+from app.services.embeddings import EmbeddingBackend, VectorSearchResult
+from app.services.search import SemanticSearchService
+
+
+class FakeBackend(EmbeddingBackend):
+    def __init__(self, vector: List[float]) -> None:
+        self._vector = list(vector)
+        self.calls: List[tuple[List[str], int]] = []
+
+    async def embed(self, texts: List[str], batch_size: int) -> List[List[float]]:  # type: ignore[override]
+        self.calls.append((list(texts), batch_size))
+        return [list(self._vector) for _ in texts]
+
+
+class FakeVectorStore:
+    def __init__(self, results: List[VectorSearchResult]) -> None:
+        self._results = list(results)
+        self.calls: List[tuple[List[float], int]] = []
+
+    async def search(self, vector: List[float], limit: int) -> List[VectorSearchResult]:
+        self.calls.append((list(vector), limit))
+        return list(self._results)
+
+
+@pytest.fixture
+def configure_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimension", 4, raising=False)
+    monkeypatch.setattr(settings, "embedding_batch_size", 8, raising=False)
+    monkeypatch.setattr(settings, "qdrant_collection_name", "test-search", raising=False)
+
+
+def test_similarity_search_reranks_results(configure_settings: None) -> None:
+    asyncio.run(_run_similarity_search_reranks_results())
+
+
+async def _run_similarity_search_reranks_results() -> None:
+    query = "quantum entanglement"
+    backend = FakeBackend([0.1, 0.2, 0.3, 0.4])
+
+    paper_ids = [uuid4() for _ in range(3)]
+    section_ids = [uuid4() for _ in range(3)]
+
+    vector_results = [
+        VectorSearchResult(
+            vector_id="vec-1",
+            score=0.82,
+            payload={
+                "paper_id": str(paper_ids[0]),
+                "section_id": str(section_ids[0]),
+                "snippet": "Background on general relativity and spacetime curvature.",
+                "page_number": 3,
+            },
+        ),
+        VectorSearchResult(
+            vector_id="vec-2",
+            score=0.78,
+            payload={
+                "paper_id": str(paper_ids[1]),
+                "section_id": str(section_ids[1]),
+                "snippet": "We explore quantum entanglement experiments across photonic lattices.",
+                "page_number": 7,
+                "char_start": 12,
+                "char_end": 86,
+            },
+        ),
+        VectorSearchResult(
+            vector_id="vec-3",
+            score=0.74,
+            payload={
+                "paper_id": str(paper_ids[2]),
+                "section_id": str(section_ids[2]),
+                "content": "Entangled particles show non-classical correlations in solid-state systems.",
+                "page_number": 10,
+            },
+        ),
+    ]
+
+    vector_store = FakeVectorStore(vector_results)
+    service = SemanticSearchService(
+        backend=backend,
+        vector_store=vector_store,  # type: ignore[arg-type]
+        rerank_top_k=3,
+        lexical_weight=0.3,
+    )
+
+    results = await service.search(query=query, limit=2)
+
+    assert backend.calls == [([query], settings.embedding_batch_size)]
+    assert vector_store.calls and vector_store.calls[0][1] >= 2
+
+    assert len(results) == 2
+    assert isinstance(results[0], SearchResult)
+    assert results[0].paper_id == paper_ids[1]
+    assert results[0].section_id == section_ids[1]
+    assert "quantum entanglement" in results[0].snippet.lower()
+    assert results[0].score > results[1].score
+
+
+def test_similarity_search_handles_blank_queries(configure_settings: None) -> None:
+    asyncio.run(_run_similarity_search_handles_blank_queries())
+
+
+async def _run_similarity_search_handles_blank_queries() -> None:
+    backend = FakeBackend([0.5, 0.5, 0.5, 0.5])
+    vector_store = FakeVectorStore([])
+    service = SemanticSearchService(
+        backend=backend,
+        vector_store=vector_store,  # type: ignore[arg-type]
+    )
+
+    results = await service.search(query="   \n\t", limit=5)
+
+    assert results == []
+    assert backend.calls == []
+    assert vector_store.calls == []


### PR DESCRIPTION
## Summary
- extend the embedding utilities with reusable backend factory, vector search support, and a semantic search service plus API endpoint
- add tests that cover the new semantic search service behaviour and API responses
- ship a dashboard semantic search panel that calls the new endpoint and renders ranked results

## Testing
- PYTHONPATH=backend pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cf7764d2f88321b7dc1b6d6ae23f5b