### PR TITLE
Add concept extraction pipeline and tests

### DIFF
--- a/backend/app/services/concept_extraction.py
+++ b/backend/app/services/concept_extraction.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from uuid import UUID
+
+from app.models.concept import Concept, ConceptCreate
+from app.models.section import SectionBase
+from app.services.concepts import replace_concepts
+from app.services.relations import replace_paper_concept_relations
+from app.services.sections import list_sections
+
+try:  # pragma: no cover - optional dependency
+    import spacy  # type: ignore[import]
+except ImportError:  # pragma: no cover - optional dependency
+    spacy = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from spacy.language import Language  # type: ignore[import]
+except ImportError:  # pragma: no cover - optional dependency
+    Language = None  # type: ignore[assignment]
+
+
+MAX_CONCEPTS = 50
+MAX_TOKENS = 6
+MIN_CHAR_LENGTH = 3
+SNIPPET_WINDOW = 120
+
+COMMON_SECTION_TITLES = {
+    "abstract",
+    "introduction",
+    "related work",
+    "background",
+    "methods",
+    "method",
+    "experiments",
+    "results",
+    "discussion",
+    "conclusion",
+    "conclusions",
+}
+
+STOPWORDS = {
+    "a",
+    "an",
+    "the",
+    "and",
+    "or",
+    "if",
+    "but",
+    "on",
+    "in",
+    "into",
+    "by",
+    "for",
+    "of",
+    "with",
+    "we",
+    "our",
+    "is",
+    "are",
+    "was",
+    "were",
+    "this",
+    "that",
+    "these",
+    "those",
+    "using",
+    "used",
+    "use",
+    "can",
+    "may",
+    "might",
+    "should",
+    "could",
+    "to",
+    "from",
+    "as",
+    "at",
+    "be",
+    "been",
+    "it",
+    "its",
+    "their",
+    "they",
+    "them",
+    "than",
+    "then",
+    "also",
+    "such",
+    "however",
+    "between",
+    "within",
+    "through",
+    "across",
+    "each",
+    "both",
+    "either",
+    "neither",
+    "because",
+    "due",
+    "after",
+    "before",
+    "over",
+    "under",
+    "more",
+    "most",
+    "less",
+    "least",
+    "many",
+    "much",
+    "several",
+    "various",
+    "against",
+    "include",
+    "includes",
+    "including",
+    "based",
+    "extend",
+    "extends",
+    "extending",
+    "extended",
+    "leveraging",
+    "leverage",
+    "leverages",
+    "utilizing",
+    "utilize",
+    "utilizes",
+    "via",
+    "around",
+    "among",
+    "amongst",
+    "towards",
+    "toward",
+    "accompanying",
+    "accompanied",
+    "accompanies",
+    "compared",
+    "comparing",
+    "compare",
+    "compares",
+}
+
+SCISPACY_MODEL_NAMES = (
+    "en_core_sci_sm",
+    "en_core_sci_md",
+    "en_core_web_sm",
+)
+
+_SCISPACY_MODEL: Optional[Language] | bool = None
+
+FILLER_PREFIXES = {
+    "baseline",
+    "baselines",
+    "compare",
+    "compares",
+    "compared",
+    "comparing",
+    "proposed",
+    "propose",
+    "proposes",
+    "introduce",
+    "introduces",
+    "introducing",
+    "novel",
+    "new",
+    "simple",
+    "improved",
+    "fast",
+    "robust",
+    "efficient",
+    "effective",
+    "powerful",
+    "general",
+}
+
+FILLER_SUFFIXES = {
+    "approach",
+    "approaches",
+    "method",
+    "methods",
+    "technique",
+    "techniques",
+    "architecture",
+    "architectures",
+    "pipeline",
+    "pipelines",
+    "framework",
+    "frameworks",
+    "model",
+    "models",
+    "system",
+    "systems",
+    "strategy",
+    "strategies",
+    "procedure",
+    "procedures",
+    "scheme",
+    "schemes",
+}
+
+
+@dataclass
+class ExtractedConcept:
+    name: str
+    type: Optional[str]
+    description: Optional[str]
+    score: float
+
+
+@dataclass
+class _Candidate:
+    name: str
+    normalized: str
+    type: Optional[str]
+    description: Optional[str]
+    score: float
+    occurrences: int = 1
+
+
+def extract_concepts_from_sections(
+    sections: Sequence[SectionBase],
+) -> List[ExtractedConcept]:
+    filtered = [section for section in sections if section.content.strip()]
+    if not filtered:
+        return []
+
+    candidates: Dict[str, _Candidate] = {}
+
+    model = _load_scispacy_model()
+    if model is not None:
+        for candidate in _extract_with_scispacy(model, filtered):
+            _merge_candidate(candidates, candidate)
+
+    for candidate in _extract_with_heuristics(filtered):
+        _merge_candidate(candidates, candidate)
+
+    if not candidates:
+        return []
+
+    ranked = sorted(
+        candidates.values(), key=lambda item: (-_final_score(item), item.name.lower())
+    )
+    top_ranked = ranked[:MAX_CONCEPTS]
+    return [
+        ExtractedConcept(
+            name=candidate.name,
+            type=candidate.type,
+            description=candidate.description,
+            score=round(_final_score(candidate), 4),
+        )
+        for candidate in top_ranked
+    ]
+
+
+async def extract_and_store_concepts(
+    paper_id: UUID,
+    sections: Optional[Sequence[SectionBase]] = None,
+) -> List[Concept]:
+    if sections is None:
+        sections = await _load_sections_for_paper(paper_id)
+
+    concepts = extract_concepts_from_sections(sections)
+    concept_models = [
+        ConceptCreate(
+            paper_id=paper_id,
+            name=concept.name,
+            type=concept.type,
+            description=concept.description,
+        )
+        for concept in concepts
+    ]
+    stored = await replace_concepts(paper_id, concept_models)
+    try:
+        await replace_paper_concept_relations(paper_id, stored, relation_type="mentions")
+    except Exception as exc:  # pragma: no cover - background task logging
+        print(
+            f"[concept_extraction] Failed to sync paper {paper_id} concept relations: {exc}"
+        )
+    return stored
+
+
+async def _load_sections_for_paper(paper_id: UUID) -> List[SectionBase]:
+    sections: List[SectionBase] = []
+    offset = 0
+    limit = 200
+    while True:
+        batch = await list_sections(paper_id=paper_id, limit=limit, offset=offset)
+        if not batch:
+            break
+        sections.extend(batch)
+        if len(batch) < limit:
+            break
+        offset += limit
+    return sections
+
+
+def _merge_candidate(registry: Dict[str, _Candidate], candidate: _Candidate) -> None:
+    if candidate.normalized in COMMON_SECTION_TITLES:
+        return
+    existing = registry.get(candidate.normalized)
+    if existing is None:
+        registry[candidate.normalized] = candidate
+        return
+    existing.score += candidate.score
+    existing.occurrences += candidate.occurrences
+    if candidate.type and (not existing.type or existing.type == "keyword"):
+        existing.type = candidate.type
+    if candidate.description and (
+        not existing.description or len(candidate.description) < len(existing.description)
+    ):
+        existing.description = candidate.description
+    existing_words = len(existing.name.split())
+    candidate_words = len(candidate.name.split())
+    if candidate_words < existing_words or (
+        candidate_words == existing_words and len(candidate.name) < len(existing.name)
+    ):
+        existing.name = candidate.name
+
+
+def _extract_with_scispacy(
+    model: Language, sections: Sequence[SectionBase]
+) -> Iterable[_Candidate]:
+    for section in sections:
+        doc = model(section.content)
+        for entity in getattr(doc, "ents", []):
+            name = _format_phrase(entity.text)
+            normalized = _normalize_concept_name(name)
+            if not normalized:
+                continue
+            snippet = _build_snippet(section.content, entity.start_char, entity.end_char)
+            description = _compose_description(section, snippet)
+            label = (entity.label_ or "entity").lower()
+            score = 4.0 + min(len(normalized.split()), 4)
+            yield _Candidate(
+                name=name,
+                normalized=normalized,
+                type=label,
+                description=description,
+                score=score,
+            )
+
+
+def _extract_with_heuristics(sections: Sequence[SectionBase]) -> Iterable[_Candidate]:
+    for section in sections:
+        for phrase, start, end in _iter_phrases(section.content):
+            normalized = _normalize_concept_name(phrase)
+            if not normalized:
+                continue
+            snippet = _build_snippet(section.content, start, end)
+            description = _compose_description(section, snippet)
+            score = 1.0 + 0.3 * min(len(normalized.split()), 4)
+            score += 0.2 if section.title else 0.0
+            score += 0.4 if phrase.isupper() else 0.0
+            yield _Candidate(
+                name=_format_phrase(phrase),
+                normalized=normalized,
+                type=_infer_concept_type(phrase),
+                description=description,
+                score=score,
+            )
+
+
+def _iter_phrases(text: str) -> Iterable[Tuple[str, int, int]]:
+    tokens = list(re.finditer(r"[A-Za-z0-9][A-Za-z0-9\-]*", text))
+    current: List[Tuple[str, int, int]] = []
+    for match in tokens:
+        token = match.group(0)
+        normalized = token.lower()
+        if normalized in STOPWORDS:
+            yield from _flush_phrase(current)
+            current = []
+            continue
+        current.append((token, match.start(), match.end()))
+        if len(current) >= MAX_TOKENS:
+            yield from _flush_phrase(current)
+            current = []
+    yield from _flush_phrase(current)
+
+
+def _flush_phrase(
+    current: List[Tuple[str, int, int]]
+) -> Iterable[Tuple[str, int, int]]:
+    if not current:
+        return []
+    words = [item[0] for item in current]
+    start = current[0][1]
+    end = current[-1][2]
+    phrase = " ".join(words)
+    tokens = len(words)
+    if tokens == 1:
+        word = words[0]
+        if len(word) < 4 and not any(char.isdigit() for char in word):
+            return []
+        if word.islower():
+            return []
+    if tokens == 0:
+        return []
+    cleaned = _normalize_concept_name(phrase)
+    if not cleaned or len(cleaned) < MIN_CHAR_LENGTH:
+        return []
+    if not any(char.isalpha() for char in cleaned):
+        return []
+    return [(phrase, start, end)]
+
+
+def _normalize_concept_name(name: str) -> str:
+    normalized = unicodedata.normalize("NFKC", name).strip()
+    normalized = normalized.replace("-", " ")
+    normalized = re.sub(r"[\(\)\[\]\{\}]+", " ", normalized)
+    normalized = re.sub(r"[^A-Za-z0-9\s]", "", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip().lower()
+    if not normalized:
+        return ""
+    parts = normalized.split()
+    trimmed = _trim_tokens(parts)
+    if trimmed:
+        parts = trimmed
+    stemmed = []
+    for part in parts:
+        if len(part) > 4 and part.endswith("s"):
+            stemmed.append(part[:-1])
+        else:
+            stemmed.append(part)
+    return " ".join(stemmed)
+
+
+def _trim_tokens(tokens: List[str]) -> List[str]:
+    start = 0
+    end = len(tokens)
+    while start < end and tokens[start] in FILLER_PREFIXES:
+        start += 1
+    while end > start and tokens[end - 1] in FILLER_SUFFIXES:
+        end -= 1
+    trimmed = list(tokens[start:end])
+    if not trimmed:
+        trimmed = list(tokens)
+    while len(trimmed) > 1 and _looks_like_acronym(trimmed[-1], trimmed[:-1]):
+        trimmed.pop()
+    return trimmed
+
+
+def _looks_like_acronym(token: str, prior_tokens: Sequence[str]) -> bool:
+    if len(prior_tokens) < 2:
+        return False
+    stripped = token.rstrip("s")
+    if len(stripped) < 2 or len(stripped) > len(prior_tokens):
+        return False
+    if not stripped.isalpha():
+        return False
+    initials = "".join(part[0] for part in prior_tokens[: len(stripped)] if part)
+    return stripped == initials.lower()
+
+
+def _format_phrase(phrase: str) -> str:
+    cleaned = unicodedata.normalize("NFKC", phrase).strip()
+    cleaned = cleaned.replace("-", " ")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    if cleaned.islower():
+        return cleaned.title()
+    return cleaned
+
+
+def _build_snippet(text: str, start: int, end: int) -> str:
+    snippet_start = max(0, start - SNIPPET_WINDOW)
+    snippet_end = min(len(text), end + SNIPPET_WINDOW)
+    snippet = text[snippet_start:snippet_end].strip()
+    snippet = re.sub(r"\s+", " ", snippet)
+    if len(snippet) > SNIPPET_WINDOW * 2:
+        snippet = snippet[: SNIPPET_WINDOW * 2].rstrip()
+        snippet += "…"
+    return snippet
+
+
+def _compose_description(section: SectionBase, snippet: str) -> Optional[str]:
+    title = (section.title or "").strip()
+    normalized_title = _normalize_concept_name(title)
+    parts: List[str] = []
+    if title and normalized_title not in COMMON_SECTION_TITLES:
+        parts.append(title)
+    if snippet:
+        parts.append(snippet)
+    if not parts:
+        return None
+    return " · ".join(parts)
+
+
+def _infer_concept_type(phrase: str) -> str:
+    if any(char.isdigit() for char in phrase):
+        return "identifier"
+    if phrase.isupper():
+        return "acronym"
+    tokens = phrase.replace("-", " ").split()
+    if len(tokens) >= 3:
+        return "method"
+    return "keyword"
+
+
+def _final_score(candidate: _Candidate) -> float:
+    return candidate.score + 0.2 * candidate.occurrences
+
+
+def _load_scispacy_model() -> Optional[Language]:
+    global _SCISPACY_MODEL
+    if _SCISPACY_MODEL is False:
+        return None
+    if _SCISPACY_MODEL not in (None, False):
+        return _SCISPACY_MODEL  # type: ignore[return-value]
+    if spacy is None or Language is None:
+        _SCISPACY_MODEL = False
+        return None
+    for model_name in SCISPACY_MODEL_NAMES:
+        try:
+            model = spacy.load(model_name)  # type: ignore[call-arg]
+        except (OSError, IOError, ImportError):  # pragma: no cover - missing model
+            continue
+        _SCISPACY_MODEL = model
+        return model
+    _SCISPACY_MODEL = False
+    return None

--- a/backend/app/services/concepts.py
+++ b/backend/app/services/concepts.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 from uuid import UUID
 
 from app.db.pool import get_pool
 from app.models.concept import Concept, ConceptCreate
+
+
+INSERT_CONCEPT_QUERY = """
+    INSERT INTO concepts (paper_id, name, type, description)
+    VALUES ($1, $2, $3, $4)
+    RETURNING id, paper_id, name, type, description, created_at, updated_at
+"""
 
 
 async def list_concepts(
@@ -28,14 +35,9 @@ async def list_concepts(
 
 async def create_concept(data: ConceptCreate) -> Concept:
     pool = get_pool()
-    query = """
-        INSERT INTO concepts (paper_id, name, type, description)
-        VALUES ($1, $2, $3, $4)
-        RETURNING id, paper_id, name, type, description, created_at, updated_at
-    """
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            query,
+            INSERT_CONCEPT_QUERY,
             data.paper_id,
             data.name,
             data.type,
@@ -54,4 +56,33 @@ async def get_concept(concept_id: UUID) -> Optional[Concept]:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(query, concept_id)
     return Concept(**dict(row)) if row else None
+
+
+async def delete_concepts_for_paper(paper_id: UUID) -> None:
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM concepts WHERE paper_id = $1", paper_id)
+
+
+async def replace_concepts(
+    paper_id: UUID, concepts: Sequence[ConceptCreate]
+) -> List[Concept]:
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("DELETE FROM concepts WHERE paper_id = $1", paper_id)
+            if not concepts:
+                return []
+
+            inserted: List[Concept] = []
+            for concept in concepts:
+                row = await conn.fetchrow(
+                    INSERT_CONCEPT_QUERY,
+                    concept.paper_id,
+                    concept.name,
+                    concept.type,
+                    concept.description,
+                )
+                inserted.append(Concept(**dict(row)))
+    return inserted
 

--- a/backend/app/services/tasks.py
+++ b/backend/app/services/tasks.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover - optional dependency
     TesseractNotFoundError = Exception  # type: ignore[assignment]
 
 from app.models.section import SectionCreate
+from app.services.concept_extraction import extract_and_store_concepts
 from app.services.embeddings import embed_paper_sections
 from app.services.papers import get_paper, update_paper_status
 from app.services.sections import replace_sections
@@ -123,6 +124,12 @@ async def parse_pdf_task(paper_id: UUID) -> None:
         ]
 
         await replace_sections(paper_id, section_models)
+        try:
+            await extract_and_store_concepts(paper_id, section_models)
+        except Exception as exc:  # pragma: no cover - background task logging
+            print(
+                f"[parse_pdf_task] Failed to extract concepts for paper {paper_id}: {exc}"
+            )
         try:
             await embed_paper_sections(paper_id)
         except Exception as exc:  # pragma: no cover - background task logging

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -173,5 +173,6 @@ def datastore(monkeypatch: pytest.MonkeyPatch) -> InMemoryDataStore:
     monkeypatch.setattr("app.services.tasks.replace_sections", store.replace_sections)
     monkeypatch.setattr("app.services.tasks.download_pdf_from_storage", store.download_pdf_from_storage)
     monkeypatch.setattr("app.services.tasks.embed_paper_sections", async_noop)
+    monkeypatch.setattr("app.services.tasks.extract_and_store_concepts", async_noop)
 
     return store

--- a/backend/tests/test_concept_extraction.py
+++ b/backend/tests/test_concept_extraction.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from datetime import datetime, timezone
+from typing import List
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.concept import Concept, ConceptCreate
+from app.models.section import SectionCreate
+from app.services.concept_extraction import (
+    extract_and_store_concepts,
+    extract_concepts_from_sections,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _make_section(content: str, *, title: str | None = None) -> SectionCreate:
+    return SectionCreate(
+        paper_id=uuid4(),
+        title=title,
+        content=content,
+        char_start=None,
+        char_end=None,
+        page_number=None,
+        snippet=None,
+    )
+
+
+def test_extract_concepts_from_sections_deduplicates_variants() -> None:
+    sections = [
+        _make_section(
+            "Graph neural networks (GNNs) are a class of deep learning models for graph "
+            "structured data. Our graph neural network architecture extends message "
+            "passing neural network techniques to temporal domains.",
+            title="Model Overview",
+        ),
+        _make_section(
+            "The Message Passing Neural Network approach is evaluated on the Cora dataset. "
+            "We compare against baseline graph neural-network methods and traditional "
+            "feature engineering baselines.",
+            title="Experimental Setup",
+        ),
+    ]
+
+    concepts = extract_concepts_from_sections(sections)
+    assert concepts
+
+    lowered = [concept.name.lower() for concept in concepts]
+    graph_mentions = [name for name in lowered if "graph neural network" in name]
+    assert len(graph_mentions) == 1
+
+    mpnn_mentions = [name for name in lowered if "message passing neural network" in name]
+    assert len(mpnn_mentions) == 1
+
+    assert any("cora dataset" in name for name in lowered)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_extract_and_store_concepts_persists_and_links(monkeypatch: pytest.MonkeyPatch) -> None:
+    paper_id = uuid4()
+    sections = [
+        _make_section(
+            "Deep learning pipelines rely on large datasets like ImageNet."
+            " Modern deep-learning research explores continual learning.",
+            title="Deep Learning Pipelines",
+        ),
+        _make_section(
+            "Continual learning benchmarks include Split CIFAR-10 and Permuted MNIST.",
+            title="Benchmarks",
+        ),
+    ]
+
+    stored_models: List[Concept] = []
+    captured_payloads: List[str] = []
+
+    async def fake_replace_concepts(
+        _: UUID, models: List[ConceptCreate]
+    ) -> List[Concept]:
+        nonlocal stored_models, captured_payloads
+        captured_payloads = [model.name for model in models]
+        now = datetime.now(timezone.utc)
+        stored_models = [
+            Concept(
+                id=uuid4(),
+                paper_id=paper_id,
+                name=model.name,
+                type=model.type,
+                description=model.description,
+                created_at=now,
+                updated_at=now,
+            )
+            for model in models
+        ]
+        return stored_models
+
+    relation_calls: List[List[str]] = []
+
+    async def fake_replace_relations(
+        _: UUID, concepts: List[Concept], relation_type: str = "mentions"
+    ) -> None:
+        relation_calls.append([concept.name for concept in concepts])
+        assert relation_type == "mentions"
+
+    monkeypatch.setattr(
+        "app.services.concept_extraction.replace_concepts", fake_replace_concepts
+    )
+    monkeypatch.setattr(
+        "app.services.concept_extraction.replace_paper_concept_relations",
+        fake_replace_relations,
+    )
+
+    results = await extract_and_store_concepts(paper_id, sections)
+    assert results == stored_models
+    assert captured_payloads
+    assert relation_calls
+
+    lower_payloads = [name.lower() for name in captured_payloads]
+    assert any("deep learning" in name for name in lower_payloads)
+    assert any("cifar" in name for name in lower_payloads)


### PR DESCRIPTION
## Summary
- add a concept extraction service that normalizes heuristic and optional spaCy entities, stores concepts, and synchronizes paper-concept relations
- extend concept persistence helpers and wire extraction into the PDF parsing task so concepts are captured during ingestion
- cover the extraction workflow with unit tests and update the in-memory test datastore patches

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf962cfd408321959f4317ddfa9935