### PR TITLE
Add graph API with overview and neighborhood endpoints

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.graph import GraphResponse
+from app.services.graph import (
+    GraphEntityNotFoundError,
+    get_graph_neighborhood,
+    get_graph_overview,
+)
+
+
+router = APIRouter(prefix="/graph", tags=["graph"])
+
+
+@router.get("/overview", response_model=GraphResponse)
+async def api_graph_overview(
+    limit: int = Query(default=100, ge=1, le=500),
+    paper_id: Optional[UUID] = Query(default=None),
+    concept_type: Optional[str] = Query(default=None, min_length=1),
+) -> GraphResponse:
+    return await get_graph_overview(limit=limit, paper_id=paper_id, concept_type=concept_type)
+
+
+@router.get("/neighborhood/{node_id}", response_model=GraphResponse)
+async def api_graph_neighborhood(
+    node_id: UUID,
+    limit: int = Query(default=50, ge=1, le=500),
+) -> GraphResponse:
+    try:
+        return await get_graph_neighborhood(node_id, limit=limit)
+    except GraphEntityNotFoundError as exc:  # pragma: no cover - handled for completeness
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from app.db.database import test_postgres_connection
 from app.services.storage import ensure_bucket_exists
 from app.api.concepts import router as concepts_router
 from app.api.evidence import router as evidence_router
+from app.api.graph import router as graph_router
 from app.api.papers import router as papers_router
 from app.api.relations import router as relations_router
 from app.api.search import router as search_router
@@ -89,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(relations_router, prefix=settings.api_prefix)
     app.include_router(evidence_router, prefix=settings.api_prefix)
     app.include_router(search_router, prefix=settings.api_prefix)
+    app.include_router(graph_router, prefix=settings.api_prefix)
 
     return app
 

--- a/backend/app/models/graph.py
+++ b/backend/app/models/graph.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+NodeType = Literal["paper", "concept"]
+
+
+class GraphNodeData(BaseModel):
+    id: str
+    type: NodeType
+    label: str
+    paper_id: Optional[UUID] = None
+    concept_id: Optional[UUID] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    class Config:
+        from_attributes = True
+
+
+class GraphNode(BaseModel):
+    data: GraphNodeData
+
+    class Config:
+        from_attributes = True
+
+
+class GraphEdgeData(BaseModel):
+    id: str
+    source: str
+    target: str
+    type: str
+    paper_id: Optional[UUID] = None
+    concept_id: Optional[UUID] = None
+    related_concept_id: Optional[UUID] = None
+    relation_id: Optional[UUID] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    class Config:
+        from_attributes = True
+
+
+class GraphEdge(BaseModel):
+    data: GraphEdgeData
+
+    class Config:
+        from_attributes = True
+
+
+class GraphMeta(BaseModel):
+    limit: int
+    node_count: int
+    edge_count: int
+    concept_count: Optional[int] = None
+    paper_count: Optional[int] = None
+    has_more: Optional[bool] = None
+    center_id: Optional[str] = None
+    center_type: Optional[NodeType] = None
+    filters: Optional[Dict[str, Any]] = None
+
+    class Config:
+        from_attributes = True
+
+
+class GraphResponse(BaseModel):
+    nodes: List[GraphNode]
+    edges: List[GraphEdge]
+    meta: GraphMeta
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/graph.py
+++ b/backend/app/services/graph.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, Dict, Optional, Set
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.graph import (
+    GraphEdge,
+    GraphEdgeData,
+    GraphMeta,
+    GraphNode,
+    GraphNodeData,
+    GraphResponse,
+)
+
+
+MAX_GRAPH_LIMIT = 500
+_RELATION_LIMIT_MULTIPLIER = 3
+
+_CONCEPT_SELECT_BASE = """
+    SELECT c.id AS concept_id,
+           c.name AS concept_name,
+           c.type AS concept_type,
+           c.description AS concept_description,
+           c.paper_id AS paper_id,
+           p.title AS paper_title,
+           p.authors AS paper_authors,
+           p.venue AS paper_venue,
+           p.year AS paper_year
+    FROM concepts c
+    JOIN papers p ON p.id = c.paper_id
+"""
+
+
+class GraphEntityNotFoundError(RuntimeError):
+    """Raised when the requested graph node cannot be located."""
+
+
+def _normalize_limit(limit: int, minimum: int = 1, maximum: int = MAX_GRAPH_LIMIT) -> int:
+    if limit < minimum:
+        return minimum
+    if limit > maximum:
+        return maximum
+    return limit
+
+
+def _concept_node_id(concept_id: UUID) -> str:
+    return f"concept:{concept_id}"
+
+
+def _paper_node_id(paper_id: UUID) -> str:
+    return f"paper:{paper_id}"
+
+
+def _paper_concept_edge_id(paper_node_id: str, concept_node_id: str) -> str:
+    return f"edge:{paper_node_id}->{concept_node_id}"
+
+
+def _clean_metadata(metadata: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    cleaned = {key: value for key, value in metadata.items() if value is not None}
+    return cleaned or None
+
+
+def _build_graph_elements(
+    concept_rows: Sequence[Mapping[str, Any]],
+    relation_rows: Sequence[Mapping[str, Any]],
+    *,
+    nodes: MutableMapping[str, GraphNode] | None = None,
+    edges: MutableMapping[str, GraphEdge] | None = None,
+    include_paper_concept_edges: bool = True,
+) -> tuple[MutableMapping[str, GraphNode], MutableMapping[str, GraphEdge]]:
+    node_map: MutableMapping[str, GraphNode] = nodes if nodes is not None else OrderedDict()
+    edge_map: MutableMapping[str, GraphEdge] = edges if edges is not None else OrderedDict()
+
+    for row in concept_rows:
+        concept_id: UUID = row["concept_id"]
+        paper_id: UUID = row["paper_id"]
+        concept_node_key = _concept_node_id(concept_id)
+        if concept_node_key not in node_map:
+            concept_metadata = _clean_metadata(
+                {
+                    "type": row.get("concept_type"),
+                    "description": row.get("concept_description"),
+                }
+            )
+            node_map[concept_node_key] = GraphNode(
+                data=GraphNodeData(
+                    id=concept_node_key,
+                    type="concept",
+                    label=row.get("concept_name") or str(concept_id),
+                    concept_id=concept_id,
+                    paper_id=paper_id,
+                    metadata=concept_metadata,
+                )
+            )
+
+        if not include_paper_concept_edges:
+            continue
+
+        paper_node_key = _paper_node_id(paper_id)
+        if paper_node_key not in node_map:
+            paper_metadata = _clean_metadata(
+                {
+                    "authors": row.get("paper_authors"),
+                    "venue": row.get("paper_venue"),
+                    "year": row.get("paper_year"),
+                }
+            )
+            node_map[paper_node_key] = GraphNode(
+                data=GraphNodeData(
+                    id=paper_node_key,
+                    type="paper",
+                    label=row.get("paper_title") or str(paper_id),
+                    paper_id=paper_id,
+                    metadata=paper_metadata,
+                )
+            )
+
+        edge_key = _paper_concept_edge_id(paper_node_key, concept_node_key)
+        if edge_key not in edge_map:
+            edge_map[edge_key] = GraphEdge(
+                data=GraphEdgeData(
+                    id=edge_key,
+                    source=paper_node_key,
+                    target=concept_node_key,
+                    type="mentions",
+                    paper_id=paper_id,
+                    concept_id=concept_id,
+                )
+            )
+
+    for row in relation_rows:
+        relation_id: Optional[UUID] = row.get("id")
+        source_concept_id: Optional[UUID] = row.get("concept_id")
+        target_concept_id: Optional[UUID] = row.get("related_concept_id")
+        if source_concept_id is None or target_concept_id is None:
+            continue
+
+        source_key = _concept_node_id(source_concept_id)
+        target_key = _concept_node_id(target_concept_id)
+        if source_key not in node_map or target_key not in node_map:
+            continue
+
+        edge_key = f"relation:{relation_id}" if relation_id is not None else f"relation:{source_key}->{target_key}"
+        if edge_key in edge_map:
+            continue
+
+        relation_metadata = _clean_metadata({"description": row.get("description")})
+        edge_map[edge_key] = GraphEdge(
+            data=GraphEdgeData(
+                id=edge_key,
+                source=source_key,
+                target=target_key,
+                type=row.get("relation_type") or "related",
+                paper_id=row.get("paper_id"),
+                concept_id=source_concept_id,
+                related_concept_id=target_concept_id,
+                relation_id=relation_id,
+                metadata=relation_metadata,
+            )
+        )
+
+    return node_map, edge_map
+
+
+async def get_graph_overview(
+    limit: int = 100,
+    *,
+    paper_id: Optional[UUID] = None,
+    concept_type: Optional[str] = None,
+) -> GraphResponse:
+    normalized_limit = _normalize_limit(limit)
+    pool = get_pool()
+
+    filters: Dict[str, Any] = {}
+    params: list[Any] = []
+    where_clauses: list[str] = []
+
+    if paper_id:
+        where_clauses.append(f"c.paper_id = ${len(params) + 1}")
+        params.append(paper_id)
+        filters["paper_id"] = str(paper_id)
+
+    if concept_type:
+        where_clauses.append(f"c.type = ${len(params) + 1}")
+        params.append(concept_type)
+        filters["concept_type"] = concept_type
+
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    limit_placeholder = len(params) + 1
+    concept_query = f"""{_CONCEPT_SELECT_BASE}
+        {where_sql}
+        ORDER BY c.created_at DESC
+        LIMIT ${limit_placeholder}
+    """
+
+    async with pool.acquire() as conn:
+        concept_rows = await conn.fetch(concept_query, *params, normalized_limit)
+        count_query = f"SELECT COUNT(*) FROM concepts c {where_sql}"
+        total_concepts = await conn.fetchval(count_query, *params)
+
+        concept_ids = [row["concept_id"] for row in concept_rows]
+        relation_rows: Sequence[Mapping[str, Any]] = []
+        if concept_ids:
+            relation_params: list[Any] = [concept_ids]
+            relation_limit_placeholder = 2
+            relation_where = "concept_id = ANY($1::uuid[]) AND related_concept_id = ANY($1::uuid[])"
+            if paper_id:
+                relation_where += f" AND paper_id = ${relation_limit_placeholder}"
+                relation_params.append(paper_id)
+                relation_limit_placeholder += 1
+            relation_params.append(min(normalized_limit * _RELATION_LIMIT_MULTIPLIER, MAX_GRAPH_LIMIT))
+            relations_query = f"""
+                SELECT id, paper_id, concept_id, related_concept_id, relation_type, description
+                FROM relations
+                WHERE {relation_where}
+                ORDER BY created_at DESC
+                LIMIT ${relation_limit_placeholder}
+            """
+            relation_rows = await conn.fetch(relations_query, *relation_params)
+
+    nodes, edges = _build_graph_elements(concept_rows, relation_rows)
+    paper_ids: Set[UUID] = {
+        node.data.paper_id
+        for node in nodes.values()
+        if node.data.type == "paper" and node.data.paper_id is not None
+    }
+    concept_node_count = sum(1 for node in nodes.values() if node.data.type == "concept")
+    meta = GraphMeta(
+        limit=normalized_limit,
+        node_count=len(nodes),
+        edge_count=len(edges),
+        concept_count=total_concepts,
+        paper_count=len(paper_ids),
+        has_more=bool(total_concepts and total_concepts > concept_node_count),
+        filters=filters or None,
+    )
+    return GraphResponse(nodes=list(nodes.values()), edges=list(edges.values()), meta=meta)
+
+
+async def get_graph_neighborhood(node_id: UUID, *, limit: int = 50) -> GraphResponse:
+    normalized_limit = _normalize_limit(limit)
+    pool = get_pool()
+
+    concept_query = f"""{_CONCEPT_SELECT_BASE}
+        WHERE c.id = $1
+    """
+
+    async with pool.acquire() as conn:
+        concept_row = await conn.fetchrow(concept_query, node_id)
+        if concept_row:
+            return await _build_concept_neighborhood(conn, concept_row, normalized_limit)
+
+        paper_row = await conn.fetchrow(
+            """
+            SELECT p.id AS paper_id,
+                   p.title AS paper_title,
+                   p.authors AS paper_authors,
+                   p.venue AS paper_venue,
+                   p.year AS paper_year
+            FROM papers p
+            WHERE p.id = $1
+            """,
+            node_id,
+        )
+        if paper_row:
+            return await _build_paper_neighborhood(conn, paper_row, normalized_limit)
+
+    raise GraphEntityNotFoundError(f"Graph node {node_id} was not found")
+
+
+async def _build_concept_neighborhood(
+    conn: Any,
+    concept_row: Mapping[str, Any],
+    limit: int,
+) -> GraphResponse:
+    nodes, edges = _build_graph_elements([concept_row], [])
+    paper_id: UUID = concept_row["paper_id"]
+    concept_id: UUID = concept_row["concept_id"]
+
+    neighbor_rows = await conn.fetch(
+        f"""{_CONCEPT_SELECT_BASE}
+            WHERE c.paper_id = $1
+            ORDER BY c.created_at DESC
+            LIMIT $2
+        """,
+        paper_id,
+        limit,
+    )
+    nodes, edges = _build_graph_elements(neighbor_rows, [], nodes=nodes, edges=edges)
+
+    total_concepts_for_paper = await conn.fetchval(
+        "SELECT COUNT(*) FROM concepts WHERE paper_id = $1",
+        paper_id,
+    )
+
+    relation_rows = await conn.fetch(
+        """
+        SELECT id, paper_id, concept_id, related_concept_id, relation_type, description
+        FROM relations
+        WHERE (concept_id = $1 OR related_concept_id = $1)
+        ORDER BY created_at DESC
+        LIMIT $2
+        """,
+        concept_id,
+        min(limit * _RELATION_LIMIT_MULTIPLIER, MAX_GRAPH_LIMIT),
+    )
+
+    existing_concept_ids: Set[UUID] = {
+        node.data.concept_id
+        for node in nodes.values()
+        if node.data.type == "concept" and node.data.concept_id is not None
+    }
+    missing_concept_ids: Set[UUID] = set()
+    for row in relation_rows:
+        source_id = row.get("concept_id")
+        target_id = row.get("related_concept_id")
+        if source_id and source_id not in existing_concept_ids:
+            missing_concept_ids.add(source_id)
+        if target_id and target_id not in existing_concept_ids:
+            missing_concept_ids.add(target_id)
+
+    if missing_concept_ids:
+        extra_rows = await conn.fetch(
+            f"""{_CONCEPT_SELECT_BASE}
+                WHERE c.id = ANY($1::uuid[])
+            """,
+            list(missing_concept_ids),
+        )
+        nodes, edges = _build_graph_elements(extra_rows, [], nodes=nodes, edges=edges)
+
+    nodes, edges = _build_graph_elements(
+        [],
+        relation_rows,
+        nodes=nodes,
+        edges=edges,
+        include_paper_concept_edges=False,
+    )
+
+    same_paper_concepts = [
+        node
+        for node in nodes.values()
+        if node.data.type == "concept" and node.data.paper_id == paper_id
+    ]
+    has_more = bool(total_concepts_for_paper and total_concepts_for_paper > len(same_paper_concepts))
+    paper_ids: Set[UUID] = {
+        node.data.paper_id
+        for node in nodes.values()
+        if node.data.type == "paper" and node.data.paper_id is not None
+    }
+
+    meta = GraphMeta(
+        limit=limit,
+        node_count=len(nodes),
+        edge_count=len(edges),
+        concept_count=total_concepts_for_paper,
+        paper_count=len(paper_ids),
+        has_more=has_more,
+        center_id=_concept_node_id(concept_id),
+        center_type="concept",
+    )
+    return GraphResponse(nodes=list(nodes.values()), edges=list(edges.values()), meta=meta)
+
+
+async def _build_paper_neighborhood(
+    conn: Any,
+    paper_row: Mapping[str, Any],
+    limit: int,
+) -> GraphResponse:
+    paper_id: UUID = paper_row["paper_id"]
+    nodes: MutableMapping[str, GraphNode] = OrderedDict()
+    edges: MutableMapping[str, GraphEdge] = OrderedDict()
+
+    paper_metadata = _clean_metadata(
+        {
+            "authors": paper_row.get("paper_authors"),
+            "venue": paper_row.get("paper_venue"),
+            "year": paper_row.get("paper_year"),
+        }
+    )
+    paper_key = _paper_node_id(paper_id)
+    nodes[paper_key] = GraphNode(
+        data=GraphNodeData(
+            id=paper_key,
+            type="paper",
+            label=paper_row.get("paper_title") or str(paper_id),
+            paper_id=paper_id,
+            metadata=paper_metadata,
+        )
+    )
+
+    concept_rows = await conn.fetch(
+        f"""{_CONCEPT_SELECT_BASE}
+            WHERE c.paper_id = $1
+            ORDER BY c.created_at DESC
+            LIMIT $2
+        """,
+        paper_id,
+        limit,
+    )
+    nodes, edges = _build_graph_elements(concept_rows, [], nodes=nodes, edges=edges)
+
+    total_concepts_for_paper = await conn.fetchval(
+        "SELECT COUNT(*) FROM concepts WHERE paper_id = $1",
+        paper_id,
+    )
+
+    concept_ids: Set[UUID] = {
+        node.data.concept_id
+        for node in nodes.values()
+        if node.data.type == "concept" and node.data.concept_id is not None and node.data.paper_id == paper_id
+    }
+
+    relation_rows: Sequence[Mapping[str, Any]] = []
+    if concept_ids:
+        relation_rows = await conn.fetch(
+            """
+            SELECT id, paper_id, concept_id, related_concept_id, relation_type, description
+            FROM relations
+            WHERE paper_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            """,
+            paper_id,
+            min(limit * _RELATION_LIMIT_MULTIPLIER, MAX_GRAPH_LIMIT),
+        )
+
+    nodes, edges = _build_graph_elements(
+        [],
+        [
+            row
+            for row in relation_rows
+            if row.get("concept_id") in concept_ids
+            and row.get("related_concept_id") in concept_ids
+        ],
+        nodes=nodes,
+        edges=edges,
+        include_paper_concept_edges=False,
+    )
+
+    paper_ids: Set[UUID] = {
+        node.data.paper_id
+        for node in nodes.values()
+        if node.data.type == "paper" and node.data.paper_id is not None
+    }
+    has_more = bool(total_concepts_for_paper and total_concepts_for_paper > len(concept_ids))
+
+    meta = GraphMeta(
+        limit=limit,
+        node_count=len(nodes),
+        edge_count=len(edges),
+        concept_count=total_concepts_for_paper,
+        paper_count=len(paper_ids),
+        has_more=has_more,
+        center_id=paper_key,
+        center_type="paper",
+    )
+    return GraphResponse(nodes=list(nodes.values()), edges=list(edges.values()), meta=meta)

--- a/backend/tests/test_graph_api.py
+++ b/backend/tests/test_graph_api.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.graph import api_graph_neighborhood, api_graph_overview
+from app.models.graph import GraphEdge, GraphEdgeData, GraphMeta, GraphNode, GraphNodeData, GraphResponse
+from app.services.graph import GraphEntityNotFoundError
+
+
+PAPER_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+CONCEPT_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _sample_response() -> GraphResponse:
+    return GraphResponse(
+        nodes=[
+            GraphNode(
+                data=GraphNodeData(
+                    id=f"paper:{PAPER_ID}",
+                    type="paper",
+                    label="Sample Paper",
+                    paper_id=PAPER_ID,
+                    metadata=None,
+                )
+            ),
+            GraphNode(
+                data=GraphNodeData(
+                    id=f"concept:{CONCEPT_ID}",
+                    type="concept",
+                    label="Concept",
+                    paper_id=PAPER_ID,
+                    concept_id=CONCEPT_ID,
+                    metadata=None,
+                )
+            ),
+        ],
+        edges=[
+            GraphEdge(
+                data=GraphEdgeData(
+                    id=f"edge:paper:{PAPER_ID}->concept:{CONCEPT_ID}",
+                    source=f"paper:{PAPER_ID}",
+                    target=f"concept:{CONCEPT_ID}",
+                    type="mentions",
+                    paper_id=PAPER_ID,
+                    concept_id=CONCEPT_ID,
+                )
+            )
+        ],
+        meta=GraphMeta(limit=10, node_count=2, edge_count=1),
+    )
+
+
+def test_api_graph_overview_delegates_to_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_api_graph_overview(monkeypatch))
+
+
+async def _run_api_graph_overview(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = _sample_response()
+
+    async def fake_get_graph_overview(*, limit: int, paper_id: UUID | None, concept_type: str | None) -> GraphResponse:
+        assert limit == 25
+        assert paper_id is None
+        assert concept_type is None
+        return expected
+
+    monkeypatch.setattr("app.api.graph.get_graph_overview", fake_get_graph_overview)
+
+    response = await api_graph_overview(limit=25, paper_id=None, concept_type=None)
+    assert response == expected
+
+
+def test_api_graph_neighborhood_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_api_graph_neighborhood_success(monkeypatch))
+
+
+async def _run_api_graph_neighborhood_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = _sample_response()
+
+    async def fake_get_graph_neighborhood(node_id: UUID, *, limit: int) -> GraphResponse:
+        assert node_id == CONCEPT_ID
+        assert limit == 5
+        return expected
+
+    monkeypatch.setattr("app.api.graph.get_graph_neighborhood", fake_get_graph_neighborhood)
+
+    response = await api_graph_neighborhood(CONCEPT_ID, limit=5)
+    assert response == expected
+
+
+def test_api_graph_neighborhood_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_api_graph_neighborhood_not_found(monkeypatch))
+
+
+async def _run_api_graph_neighborhood_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_graph_neighborhood(node_id: UUID, *, limit: int) -> GraphResponse:
+        raise GraphEntityNotFoundError("missing")
+
+    monkeypatch.setattr("app.api.graph.get_graph_neighborhood", fake_get_graph_neighborhood)
+
+    with pytest.raises(HTTPException) as exc:
+        await api_graph_neighborhood(CONCEPT_ID, limit=5)
+
+    assert exc.value.status_code == 404
+    assert "missing" in str(exc.value.detail)

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Iterable, List, Mapping
+from uuid import UUID
+
+import pytest
+
+from app.models.graph import GraphResponse
+from app.services.graph import (
+    GraphEntityNotFoundError,
+    get_graph_neighborhood,
+    get_graph_overview,
+)
+
+
+PAPER_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+PAPER_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+CONCEPT_ALPHA = UUID("11111111-1111-1111-1111-111111111111")
+CONCEPT_BETA = UUID("22222222-2222-2222-2222-222222222222")
+CONCEPT_GAMMA = UUID("33333333-3333-3333-3333-333333333333")
+RELATION_ALPHA = UUID("44444444-4444-4444-4444-444444444444")
+RELATION_BETA = UUID("55555555-5555-5555-5555-555555555555")
+
+
+class FakeAcquireContext:
+    def __init__(self, conn: "FakeGraphConnection") -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> "FakeGraphConnection":
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - nothing to clean up
+        return False
+
+
+class FakePool:
+    def __init__(self, conn: "FakeGraphConnection") -> None:
+        self._conn = conn
+
+    def acquire(self) -> FakeAcquireContext:
+        return FakeAcquireContext(self._conn)
+
+
+class FakeGraphConnection:
+    def __init__(self) -> None:
+        self._papers: Dict[UUID, Dict[str, Any]] = {
+            PAPER_A: {
+                "id": PAPER_A,
+                "title": "Quantum Linking",
+                "authors": "Ada Lovelace",
+                "venue": "SciConf",
+                "year": 2023,
+            },
+            PAPER_B: {
+                "id": PAPER_B,
+                "title": "Graph Learning",
+                "authors": "Alan Turing",
+                "venue": "MLSymposium",
+                "year": 2024,
+            },
+        }
+        self._concepts: Dict[UUID, Dict[str, Any]] = {
+            CONCEPT_ALPHA: {
+                "id": CONCEPT_ALPHA,
+                "paper_id": PAPER_A,
+                "name": "Quantum Fields",
+                "type": "physics",
+                "description": "Field theory overview",
+                "created_at": 1,
+            },
+            CONCEPT_BETA: {
+                "id": CONCEPT_BETA,
+                "paper_id": PAPER_A,
+                "name": "Gauge Symmetry",
+                "type": "physics",
+                "description": "Symmetry discussion",
+                "created_at": 2,
+            },
+            CONCEPT_GAMMA: {
+                "id": CONCEPT_GAMMA,
+                "paper_id": PAPER_B,
+                "name": "Graph Embeddings",
+                "type": "ml",
+                "description": "Embedding pipelines",
+                "created_at": 3,
+            },
+        }
+        self._relations: Dict[UUID, Dict[str, Any]] = {
+            RELATION_ALPHA: {
+                "id": RELATION_ALPHA,
+                "paper_id": PAPER_A,
+                "concept_id": CONCEPT_ALPHA,
+                "related_concept_id": CONCEPT_BETA,
+                "relation_type": "related_to",
+                "description": "Alpha influences Beta",
+                "created_at": 10,
+            },
+            RELATION_BETA: {
+                "id": RELATION_BETA,
+                "paper_id": PAPER_A,
+                "concept_id": CONCEPT_BETA,
+                "related_concept_id": CONCEPT_GAMMA,
+                "relation_type": "extends",
+                "description": "Cross paper relationship",
+                "created_at": 8,
+            },
+        }
+
+    # AsyncPG compatibility helpers -------------------------------------------------
+    async def fetch(self, query: str, *params: Any) -> List[Mapping[str, Any]]:
+        normalized = " ".join(query.split())
+        if normalized.startswith("SELECT c.id AS concept_id"):
+            if "WHERE c.id = ANY" in normalized:
+                concept_ids = set(params[0])
+                return [self._build_concept_row(rec) for rec in self._filter_concepts(ids=concept_ids)]
+            paper_id, concept_type, limit = self._parse_concept_filters(normalized, list(params))
+            concepts = self._filter_concepts(paper_id=paper_id, concept_type=concept_type)
+            return [self._build_concept_row(rec) for rec in concepts[:limit]]
+
+        if normalized.startswith("SELECT id, paper_id, concept_id, related_concept_id, relation_type, description FROM relations"):
+            if "concept_id = ANY($1::uuid[]) AND related_concept_id = ANY($1::uuid[])" in normalized:
+                concept_ids = set(params[0])
+                idx = 1
+                paper_filter = None
+                if "AND paper_id = $2" in normalized:
+                    paper_filter = params[1]
+                    idx = 2
+                limit = params[idx]
+                relations = self._relations_between(concept_ids, paper_filter)
+                return [self._build_relation_row(rec) for rec in relations[:limit]]
+            if "WHERE (concept_id = $1 OR related_concept_id = $1)" in normalized:
+                concept_id = params[0]
+                limit = params[1]
+                relations = self._relations_touching(concept_id)
+                return [self._build_relation_row(rec) for rec in relations[:limit]]
+            if "WHERE paper_id = $1" in normalized:
+                paper_id = params[0]
+                limit = params[1]
+                relations = self._relations_for_paper(paper_id)
+                return [self._build_relation_row(rec) for rec in relations[:limit]]
+
+        raise AssertionError(f"Unsupported fetch query: {normalized}")
+
+    async def fetchrow(self, query: str, *params: Any) -> Mapping[str, Any] | None:
+        normalized = " ".join(query.split())
+        if normalized.startswith("SELECT c.id AS concept_id") and "WHERE c.id = $1" in normalized:
+            concept_id = params[0]
+            concepts = self._filter_concepts(ids={concept_id})
+            return self._build_concept_row(concepts[0]) if concepts else None
+        if normalized.startswith("SELECT p.id AS paper_id") and "WHERE p.id = $1" in normalized:
+            paper_id = params[0]
+            paper = self._papers.get(paper_id)
+            return self._build_paper_row(paper) if paper else None
+        raise AssertionError(f"Unsupported fetchrow query: {normalized}")
+
+    async def fetchval(self, query: str, *params: Any) -> Any:
+        normalized = " ".join(query.split())
+        if normalized.startswith("SELECT COUNT(*) FROM concepts c"):
+            paper_id, concept_type, _ = self._parse_concept_filters(normalized, list(params), include_limit=False)
+            return len(self._filter_concepts(paper_id=paper_id, concept_type=concept_type))
+        if normalized.startswith("SELECT COUNT(*) FROM concepts WHERE paper_id = $1"):
+            paper_id = params[0]
+            return len(self._filter_concepts(paper_id=paper_id))
+        raise AssertionError(f"Unsupported fetchval query: {normalized}")
+
+    # Helpers ----------------------------------------------------------------------
+    def _filter_concepts(
+        self,
+        *,
+        paper_id: UUID | None = None,
+        concept_type: str | None = None,
+        ids: Iterable[UUID] | None = None,
+    ) -> List[Dict[str, Any]]:
+        records = list(self._concepts.values())
+        if ids is not None:
+            target = set(ids)
+            records = [rec for rec in records if rec["id"] in target]
+        if paper_id is not None:
+            records = [rec for rec in records if rec["paper_id"] == paper_id]
+        if concept_type is not None:
+            records = [rec for rec in records if rec["type"] == concept_type]
+        records.sort(key=lambda rec: rec["created_at"], reverse=True)
+        return records
+
+    def _parse_concept_filters(
+        self,
+        normalized_query: str,
+        params: List[Any],
+        *,
+        include_limit: bool = True,
+    ) -> tuple[UUID | None, str | None, int]:
+        paper_id = None
+        concept_type = None
+        limit = params[-1] if include_limit and params else 0
+
+        if "WHERE c.paper_id = $1 AND c.type = $2" in normalized_query:
+            paper_id = params[0]
+            concept_type = params[1]
+            if include_limit:
+                limit = params[2]
+        elif "WHERE c.paper_id = $1" in normalized_query and "AND" not in normalized_query.split("WHERE c.paper_id = $1", 1)[1][:5]:
+            paper_id = params[0]
+            if include_limit:
+                limit = params[1]
+        elif "WHERE c.type = $1" in normalized_query:
+            concept_type = params[0]
+            if include_limit:
+                limit = params[1]
+        elif include_limit:
+            limit = params[0]
+
+        return paper_id, concept_type, limit
+
+    def _build_concept_row(self, concept: Mapping[str, Any]) -> Dict[str, Any]:
+        paper = self._papers[concept["paper_id"]]
+        return {
+            "concept_id": concept["id"],
+            "concept_name": concept["name"],
+            "concept_type": concept["type"],
+            "concept_description": concept["description"],
+            "paper_id": concept["paper_id"],
+            "paper_title": paper["title"],
+            "paper_authors": paper["authors"],
+            "paper_venue": paper["venue"],
+            "paper_year": paper["year"],
+        }
+
+    def _build_paper_row(self, paper: Mapping[str, Any] | None) -> Dict[str, Any] | None:
+        if not paper:
+            return None
+        return {
+            "paper_id": paper["id"],
+            "paper_title": paper["title"],
+            "paper_authors": paper["authors"],
+            "paper_venue": paper["venue"],
+            "paper_year": paper["year"],
+        }
+
+    def _build_relation_row(self, relation: Mapping[str, Any]) -> Dict[str, Any]:
+        return {
+            "id": relation["id"],
+            "paper_id": relation["paper_id"],
+            "concept_id": relation["concept_id"],
+            "related_concept_id": relation["related_concept_id"],
+            "relation_type": relation["relation_type"],
+            "description": relation["description"],
+        }
+
+    def _relations_between(
+        self,
+        concept_ids: Iterable[UUID],
+        paper_filter: UUID | None,
+    ) -> List[Dict[str, Any]]:
+        targets = set(concept_ids)
+        relations = [
+            rel
+            for rel in self._relations.values()
+            if rel["concept_id"] in targets and rel["related_concept_id"] in targets
+        ]
+        if paper_filter is not None:
+            relations = [rel for rel in relations if rel["paper_id"] == paper_filter]
+        relations.sort(key=lambda rec: rec["created_at"], reverse=True)
+        return relations
+
+    def _relations_touching(self, concept_id: UUID) -> List[Dict[str, Any]]:
+        relations = [
+            rel
+            for rel in self._relations.values()
+            if rel["concept_id"] == concept_id or rel["related_concept_id"] == concept_id
+        ]
+        relations.sort(key=lambda rec: rec["created_at"], reverse=True)
+        return relations
+
+    def _relations_for_paper(self, paper_id: UUID) -> List[Dict[str, Any]]:
+        relations = [rel for rel in self._relations.values() if rel["paper_id"] == paper_id]
+        relations.sort(key=lambda rec: rec["created_at"], reverse=True)
+        return relations
+
+
+def _setup_fake_pool(monkeypatch: pytest.MonkeyPatch) -> FakePool:
+    conn = FakeGraphConnection()
+    pool = FakePool(conn)
+    monkeypatch.setattr("app.services.graph.get_pool", lambda: pool)
+    return pool
+
+
+def test_get_graph_overview_returns_concepts_and_relations(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_get_graph_overview(monkeypatch))
+
+
+async def _run_get_graph_overview(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_fake_pool(monkeypatch)
+
+    response = await get_graph_overview(limit=5)
+
+    assert isinstance(response, GraphResponse)
+    assert response.meta.limit == 5
+    assert response.meta.concept_count == 3
+    assert response.meta.paper_count == 2
+    assert not response.meta.has_more
+
+    concept_ids = {node.data.concept_id for node in response.nodes if node.data.type == "concept"}
+    assert concept_ids == {CONCEPT_ALPHA, CONCEPT_BETA, CONCEPT_GAMMA}
+
+    relation_ids = {edge.data.relation_id for edge in response.edges if edge.data.relation_id}
+    assert RELATION_ALPHA in relation_ids
+    assert RELATION_BETA in relation_ids
+
+
+def test_get_graph_neighborhood_for_concept(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_get_graph_neighborhood_for_concept(monkeypatch))
+
+
+async def _run_get_graph_neighborhood_for_concept(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_fake_pool(monkeypatch)
+
+    response = await get_graph_neighborhood(CONCEPT_BETA, limit=3)
+
+    concept_ids = {node.data.concept_id for node in response.nodes if node.data.type == "concept"}
+    assert {CONCEPT_ALPHA, CONCEPT_BETA, CONCEPT_GAMMA}.issubset(concept_ids)
+
+    assert response.meta.center_type == "concept"
+    assert response.meta.center_id.endswith(str(CONCEPT_BETA))
+    assert response.meta.concept_count == 2  # two concepts share the primary paper
+    assert response.meta.paper_count >= 1
+
+    relation_pairs = {
+        (edge.data.concept_id, edge.data.related_concept_id)
+        for edge in response.edges
+        if edge.data.relation_id == RELATION_BETA
+    }
+    assert (CONCEPT_BETA, CONCEPT_GAMMA) in relation_pairs
+
+
+def test_get_graph_neighborhood_for_paper(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_get_graph_neighborhood_for_paper(monkeypatch))
+
+
+async def _run_get_graph_neighborhood_for_paper(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_fake_pool(monkeypatch)
+
+    response = await get_graph_neighborhood(PAPER_A, limit=5)
+
+    assert response.meta.center_type == "paper"
+    assert response.meta.center_id.endswith(str(PAPER_A))
+    assert response.meta.concept_count == 2
+    assert not response.meta.has_more
+
+    concept_ids = {node.data.concept_id for node in response.nodes if node.data.type == "concept"}
+    assert concept_ids == {CONCEPT_ALPHA, CONCEPT_BETA}
+
+    relation_ids = {edge.data.relation_id for edge in response.edges if edge.data.relation_id}
+    assert relation_ids == {RELATION_ALPHA}
+
+
+def test_get_graph_neighborhood_missing_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_run_get_graph_neighborhood_missing_node(monkeypatch))
+
+
+async def _run_get_graph_neighborhood_missing_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_fake_pool(monkeypatch)
+
+    missing_id = UUID("99999999-9999-9999-9999-999999999999")
+    with pytest.raises(GraphEntityNotFoundError):
+        await get_graph_neighborhood(missing_id, limit=3)


### PR DESCRIPTION
## Summary
- add Pydantic graph response models and backend service helpers for building Cytoscape-ready nodes and edges
- expose /graph/overview and /graph/neighborhood endpoints that support filters and progressive loading metadata
- cover the new graph functionality with API and service tests

## Testing
- PYTHONPATH=. pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf9f1bb9f88321aab1a87dbccbedd0