### PR TITLE
Add typed ontology schema and models

### DIFF
--- a/backend/app/db/migrations/0005_typed_ontology.sql
+++ b/backend/app/db/migrations/0005_typed_ontology.sql
@@ -1,0 +1,150 @@
+-- Enums for typed research structures
+DO $$
+BEGIN
+    CREATE TYPE claim_category AS ENUM (
+        'contribution',
+        'limitation',
+        'ablation',
+        'future_work',
+        'other'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END$$;
+
+DO $$
+BEGIN
+    CREATE TYPE paper_relation_type AS ENUM (
+        'cites',
+        'extends',
+        'compares'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END$$;
+
+DO $$
+BEGIN
+    CREATE TYPE concept_resolution_type AS ENUM (
+        'method',
+        'dataset',
+        'metric',
+        'task'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END$$;
+
+-- Core ontology entities
+CREATE TABLE IF NOT EXISTS methods (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    aliases JSONB NOT NULL DEFAULT '[]'::jsonb,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    aliases JSONB NOT NULL DEFAULT '[]'::jsonb,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS datasets (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    aliases JSONB NOT NULL DEFAULT '[]'::jsonb,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS metrics (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    unit TEXT,
+    aliases JSONB NOT NULL DEFAULT '[]'::jsonb,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Result statements tie together ontology entities with evidence
+CREATE TABLE IF NOT EXISTS results (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    method_id UUID REFERENCES methods(id) ON DELETE SET NULL,
+    dataset_id UUID REFERENCES datasets(id) ON DELETE SET NULL,
+    metric_id UUID REFERENCES metrics(id) ON DELETE SET NULL,
+    task_id UUID REFERENCES tasks(id) ON DELETE SET NULL,
+    split TEXT,
+    value_numeric NUMERIC(8,3),
+    value_text TEXT,
+    is_sota BOOLEAN NOT NULL DEFAULT FALSE,
+    confidence DOUBLE PRECISION,
+    evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Claims summarise findings with typed evidence
+CREATE TABLE IF NOT EXISTS claims (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    category claim_category NOT NULL,
+    text TEXT NOT NULL,
+    confidence DOUBLE PRECISION,
+    evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Paper-to-paper relationships with citations and provenance
+CREATE TABLE IF NOT EXISTS paper_relations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    src_paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    dst_paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    relation_type paper_relation_type NOT NULL,
+    confidence DOUBLE PRECISION,
+    evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Canonicalisation mappings between raw aliases and ontology entities
+CREATE TABLE IF NOT EXISTS concept_resolutions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    resolution_type concept_resolution_type NOT NULL,
+    canonical_id UUID NOT NULL,
+    alias_text TEXT NOT NULL,
+    score DOUBLE PRECISION,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for fast lookup of ontology concepts and resolutions
+CREATE INDEX IF NOT EXISTS idx_methods_name ON methods (lower(name));
+CREATE INDEX IF NOT EXISTS idx_tasks_name ON tasks (lower(name));
+CREATE INDEX IF NOT EXISTS idx_datasets_name ON datasets (lower(name));
+CREATE INDEX IF NOT EXISTS idx_metrics_name ON metrics (lower(name));
+
+CREATE INDEX IF NOT EXISTS idx_methods_aliases ON methods USING GIN (aliases);
+CREATE INDEX IF NOT EXISTS idx_tasks_aliases ON tasks USING GIN (aliases);
+CREATE INDEX IF NOT EXISTS idx_datasets_aliases ON datasets USING GIN (aliases);
+CREATE INDEX IF NOT EXISTS idx_metrics_aliases ON metrics USING GIN (aliases);
+
+CREATE INDEX IF NOT EXISTS idx_results_paper_dataset_metric_method
+    ON results (paper_id, dataset_id, metric_id, method_id);
+
+CREATE INDEX IF NOT EXISTS idx_claims_paper_id ON claims (paper_id);
+CREATE INDEX IF NOT EXISTS idx_paper_relations_src ON paper_relations (src_paper_id);
+CREATE INDEX IF NOT EXISTS idx_paper_relations_dst ON paper_relations (dst_paper_id);
+CREATE INDEX IF NOT EXISTS idx_concept_resolutions_alias
+    ON concept_resolutions (lower(alias_text));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_concept_resolutions_unique
+    ON concept_resolutions (resolution_type, canonical_id, lower(alias_text));
+

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,10 +1,39 @@
 
 from .concept import Concept, ConceptBase, ConceptCreate
 from .evidence import Evidence, EvidenceBase, EvidenceCreate
+from .ontology import (
+    Claim,
+    ClaimBase,
+    ClaimCreate,
+    ClaimCategory,
+    ConceptResolution,
+    ConceptResolutionBase,
+    ConceptResolutionCreate,
+    ConceptResolutionType,
+    Dataset,
+    DatasetBase,
+    DatasetCreate,
+    Method,
+    MethodBase,
+    MethodCreate,
+    Metric,
+    MetricBase,
+    MetricCreate,
+    PaperRelation,
+    PaperRelationBase,
+    PaperRelationCreate,
+    PaperRelationType,
+    Result,
+    ResultBase,
+    ResultCreate,
+    Task,
+    TaskBase,
+    TaskCreate,
+)
 from .paper import Paper, PaperBase, PaperCreate
 from .relation import Relation, RelationBase, RelationCreate
-from .section import Section, SectionBase, SectionCreate
 from .search import SearchResult
+from .section import Section, SectionBase, SectionCreate
 
 __all__ = [
     "Paper",
@@ -23,5 +52,32 @@ __all__ = [
     "EvidenceBase",
     "EvidenceCreate",
     "SearchResult",
+    "Method",
+    "MethodBase",
+    "MethodCreate",
+    "Task",
+    "TaskBase",
+    "TaskCreate",
+    "Dataset",
+    "DatasetBase",
+    "DatasetCreate",
+    "Metric",
+    "MetricBase",
+    "MetricCreate",
+    "Result",
+    "ResultBase",
+    "ResultCreate",
+    "Claim",
+    "ClaimBase",
+    "ClaimCreate",
+    "ClaimCategory",
+    "PaperRelation",
+    "PaperRelationBase",
+    "PaperRelationCreate",
+    "PaperRelationType",
+    "ConceptResolution",
+    "ConceptResolutionBase",
+    "ConceptResolutionCreate",
+    "ConceptResolutionType",
 ]
 

--- a/backend/app/models/ontology.py
+++ b/backend/app/models/ontology.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+EvidencePayload = list[dict[str, Any]]
+
+
+class _AliasMixin(BaseModel):
+    name: str = Field(..., min_length=1)
+    aliases: list[str] = Field(default_factory=list)
+    description: Optional[str] = None
+
+
+class MethodBase(_AliasMixin):
+    pass
+
+
+class MethodCreate(MethodBase):
+    pass
+
+
+class Method(MethodBase):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class TaskBase(_AliasMixin):
+    pass
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class Task(TaskBase):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DatasetBase(_AliasMixin):
+    pass
+
+
+class DatasetCreate(DatasetBase):
+    pass
+
+
+class Dataset(DatasetBase):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class MetricBase(_AliasMixin):
+    unit: Optional[str] = None
+
+
+class MetricCreate(MetricBase):
+    pass
+
+
+class Metric(MetricBase):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ClaimCategory(str, Enum):
+    CONTRIBUTION = "contribution"
+    LIMITATION = "limitation"
+    ABLATION = "ablation"
+    FUTURE_WORK = "future_work"
+    OTHER = "other"
+
+
+class PaperRelationType(str, Enum):
+    CITES = "cites"
+    EXTENDS = "extends"
+    COMPARES = "compares"
+
+
+class ConceptResolutionType(str, Enum):
+    METHOD = "method"
+    DATASET = "dataset"
+    METRIC = "metric"
+    TASK = "task"
+
+
+class ResultBase(BaseModel):
+    method_id: Optional[UUID] = None
+    dataset_id: Optional[UUID] = None
+    metric_id: Optional[UUID] = None
+    task_id: Optional[UUID] = None
+    split: Optional[str] = None
+    value_numeric: Optional[Decimal] = None
+    value_text: Optional[str] = None
+    is_sota: bool = False
+    confidence: Optional[float] = None
+    evidence: EvidencePayload = Field(default_factory=list)
+
+
+class ResultCreate(ResultBase):
+    paper_id: UUID
+
+
+class Result(ResultBase):
+    id: UUID
+    paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ClaimBase(BaseModel):
+    category: ClaimCategory
+    text: str = Field(..., min_length=1)
+    confidence: Optional[float] = None
+    evidence: EvidencePayload = Field(default_factory=list)
+
+
+class ClaimCreate(ClaimBase):
+    paper_id: UUID
+
+
+class Claim(ClaimBase):
+    id: UUID
+    paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class PaperRelationBase(BaseModel):
+    dst_paper_id: UUID
+    relation_type: PaperRelationType
+    confidence: Optional[float] = None
+    evidence: EvidencePayload = Field(default_factory=list)
+
+
+class PaperRelationCreate(PaperRelationBase):
+    src_paper_id: UUID
+
+
+class PaperRelation(PaperRelationBase):
+    id: UUID
+    src_paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ConceptResolutionBase(BaseModel):
+    resolution_type: ConceptResolutionType
+    canonical_id: UUID
+    alias_text: str = Field(..., min_length=1)
+    score: Optional[float] = None
+
+
+class ConceptResolutionCreate(ConceptResolutionBase):
+    pass
+
+
+class ConceptResolution(ConceptResolutionBase):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+


### PR DESCRIPTION
## Summary
- add a migration that introduces typed ontology tables, enums, and supporting indexes for methods, datasets, metrics, tasks, results, claims, paper relations, and concept resolutions
- scaffold Pydantic models and enums representing the new ontology entities and expose them via the models package

## Testing
- PYTHONPATH=backend pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cfd30be520832189acc3c33aafc9df