### PR TITLE
Implement tier 3 verification for extractions

### DIFF
--- a/backend/app/api/extraction.py
+++ b/backend/app/api/extraction.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from app.services.extraction_tier1 import run_tier1_extraction
 from app.services.extraction_tier2 import Tier2ValidationError, run_tier2_structurer
+from app.services.extraction_tier3 import run_tier3_verifier
 
 
 router = APIRouter(prefix="/extract", tags=["extraction"])
@@ -18,7 +19,7 @@ async def api_run_extraction(
         default="1",
         description=(
             "Comma separated list of extraction tiers to execute "
-            "(supported tiers: 1, 2)."
+            "(supported tiers: 1, 2, 3)."
         ),
     ),
 ):
@@ -26,13 +27,13 @@ async def api_run_extraction(
     if not requested:
         requested = {"1"}
 
-    unsupported = sorted(tier for tier in requested if tier not in {"1", "2"})
+    unsupported = sorted(tier for tier in requested if tier not in {"1", "2", "3"})
     if unsupported:
         raise HTTPException(
             status_code=400,
             detail=(
                 "Unsupported extraction tiers requested: "
-                f"{', '.join(unsupported)}. Supported tiers are 1 and 2."
+                f"{', '.join(unsupported)}. Supported tiers are 1, 2, and 3."
             ),
         )
 
@@ -42,6 +43,13 @@ async def api_run_extraction(
             summary = await run_tier1_extraction(paper_id)
         if "2" in requested:
             summary = await run_tier2_structurer(paper_id, base_summary=summary)
+        if "3" in requested:
+            if summary is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Tier 3 verification requires results from earlier tiers.",
+                )
+            summary = await run_tier3_verifier(paper_id, base_summary=summary)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Tier2ValidationError as exc:

--- a/backend/app/db/migrations/0005_typed_ontology.sql
+++ b/backend/app/db/migrations/0005_typed_ontology.sql
@@ -87,6 +87,8 @@ CREATE TABLE IF NOT EXISTS results (
     is_sota BOOLEAN NOT NULL DEFAULT FALSE,
     confidence DOUBLE PRECISION,
     evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+    verified BOOLEAN,
+    verifier_notes TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/backend/app/models/ontology.py
+++ b/backend/app/models/ontology.py
@@ -118,6 +118,8 @@ class ResultBase(BaseModel):
     is_sota: bool = False
     confidence: Optional[float] = None
     evidence: EvidencePayload = Field(default_factory=list)
+    verified: Optional[bool] = None
+    verifier_notes: Optional[str] = None
 
 
 class ResultCreate(ResultBase):

--- a/backend/app/services/extraction_tier1.py
+++ b/backend/app/services/extraction_tier1.py
@@ -980,6 +980,8 @@ def _serialize_result(
         "is_sota": result.is_sota,
         "confidence": result.confidence,
         "evidence": result.evidence,
+        "verified": result.verified,
+        "verifier_notes": result.verifier_notes,
         "created_at": result.created_at.isoformat(),
         "updated_at": result.updated_at.isoformat(),
     }

--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -295,6 +295,8 @@ async def _summary_result_to_model(
         is_sota=bool(payload.get("is_sota")),
         confidence=payload.get("confidence"),
         evidence=list(payload.get("evidence") or []),
+        verified=payload.get("verified"),
+        verifier_notes=payload.get("verifier_notes"),
     )
 
 
@@ -621,6 +623,8 @@ def _serialize_result(
         "is_sota": result.is_sota,
         "confidence": result.confidence,
         "evidence": result.evidence,
+        "verified": result.verified,
+        "verifier_notes": result.verifier_notes,
         "created_at": result.created_at.isoformat(),
         "updated_at": result.updated_at.isoformat(),
     }

--- a/backend/app/services/extraction_tier3.py
+++ b/backend/app/services/extraction_tier3.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from decimal import Decimal
+import re
+from typing import Any, Iterable, Sequence
+from uuid import UUID
+
+from app.models.ontology import ResultCreate
+from app.models.section import Section
+from app.services.ontology_store import replace_results
+from app.services.papers import get_paper
+from app.services.sections import list_sections
+
+
+TIER_NAME = "tier3_verifier"
+_VALUE_PATTERN = re.compile(r"-?\d+(?:\.\d+)?")
+_SPAN_WINDOW = 80
+
+
+@dataclass(slots=True)
+class _VerificationOutcome:
+    result: ResultCreate
+    notes: list[str]
+    matched_span: bool
+
+
+async def run_tier3_verifier(
+    paper_id: UUID,
+    *,
+    base_summary: dict[str, Any] | None = None,
+    sections: Sequence[Section] | None = None,
+) -> dict[str, Any]:
+    """Cross-check stored results against the paper text and annotate verification."""
+
+    if base_summary is None:
+        raise ValueError("Tier-3 verifier requires an existing summary to audit")
+
+    paper = await get_paper(paper_id)
+    if paper is None:
+        raise ValueError(f"Paper {paper_id} does not exist")
+
+    if sections is None:
+        sections = await list_sections(paper_id=paper_id, limit=500, offset=0)
+
+    section_lookup = {str(section.id): section for section in sections}
+
+    method_payloads = _build_entity_lookup(base_summary.get("methods", []))
+    dataset_payloads = _build_entity_lookup(base_summary.get("datasets", []))
+    metric_payloads = _build_entity_lookup(base_summary.get("metrics", []))
+    task_payloads = _build_entity_lookup(base_summary.get("tasks", []))
+
+    results_payload = list(base_summary.get("results", []))
+    result_models: list[ResultCreate] = []
+    audit_entries: list[dict[str, Any]] = []
+
+    for index, payload in enumerate(results_payload):
+        model = _summary_result_to_model(paper_id, payload)
+        metric_payload = metric_payloads.get(model.metric_id)
+
+        outcome = _verify_result(
+            model,
+            metric_payload=metric_payload,
+            sections=section_lookup,
+        )
+        result_models.append(outcome.result)
+
+        audit_entries.append(
+            {
+                "index": index,
+                "method": _lookup_name(method_payloads, model.method_id),
+                "dataset": _lookup_name(dataset_payloads, model.dataset_id),
+                "metric": _lookup_name(metric_payloads, model.metric_id),
+                "verified": outcome.result.verified,
+                "confidence": outcome.result.confidence,
+                "matched_span": outcome.matched_span,
+                "notes": outcome.notes or None,
+            }
+        )
+
+    stored_results = await replace_results(paper_id, result_models)
+
+    tiers = _merge_tiers(base_summary.get("tiers", []), [3])
+
+    summary_payload = {
+        "paper_id": str(paper_id),
+        "tiers": tiers,
+        "methods": copy.deepcopy(base_summary.get("methods", [])),
+        "datasets": copy.deepcopy(base_summary.get("datasets", [])),
+        "metrics": copy.deepcopy(base_summary.get("metrics", [])),
+        "tasks": copy.deepcopy(base_summary.get("tasks", [])),
+        "results": [],
+        "claims": copy.deepcopy(base_summary.get("claims", [])),
+        "audit_log": audit_entries,
+    }
+
+    tier_by_index = [payload.get("tier") for payload in results_payload]
+
+    for index, result in enumerate(stored_results):
+        serialized = _serialize_result(
+            result,
+            method_payloads=method_payloads,
+            dataset_payloads=dataset_payloads,
+            metric_payloads=metric_payloads,
+            task_payloads=task_payloads,
+        )
+        tier_value = tier_by_index[index] if index < len(tier_by_index) else None
+        if tier_value is not None:
+            serialized["tier"] = tier_value
+        serialized["verifier"] = TIER_NAME
+        summary_payload["results"].append(serialized)
+
+    return summary_payload
+
+
+def _verify_result(
+    model: ResultCreate,
+    *,
+    metric_payload: dict[str, Any] | None,
+    sections: dict[str, Section],
+) -> _VerificationOutcome:
+    notes: list[str] = []
+    matched_span = False
+
+    numeric_value = model.value_numeric
+    text_value = model.value_text.strip() if model.value_text else None
+    confidence = float(model.confidence) if model.confidence is not None else 0.5
+
+    normalized_numeric, normalized_text, normalization_notes = _normalize_value(
+        numeric_value,
+        text_value,
+        metric_payload,
+    )
+    if normalization_notes:
+        notes.extend(normalization_notes)
+
+    numeric_value = normalized_numeric
+    text_value = normalized_text
+
+    if numeric_value is None:
+        notes.append("unable to determine numeric value for verification")
+
+    is_outlier, outlier_note = _detect_outlier(numeric_value, metric_payload)
+    verified = numeric_value is not None and not is_outlier
+
+    if outlier_note:
+        notes.append(outlier_note)
+
+    if verified:
+        matched_span, span_note = _match_value_in_evidence(
+            numeric_value,
+            text_value,
+            model.evidence,
+            sections,
+            metric_payload,
+        )
+        if span_note:
+            notes.append(span_note)
+        if matched_span:
+            confidence = min(confidence + 0.1, 1.0)
+        else:
+            confidence = max(confidence - 0.2, 0.0)
+            verified = False
+
+    verifier_notes = _combine_notes(notes)
+
+    updated_model = ResultCreate(
+        paper_id=model.paper_id,
+        method_id=model.method_id,
+        dataset_id=model.dataset_id,
+        metric_id=model.metric_id,
+        task_id=model.task_id,
+        split=model.split,
+        value_numeric=numeric_value,
+        value_text=text_value,
+        is_sota=model.is_sota,
+        confidence=confidence,
+        evidence=model.evidence,
+        verified=verified,
+        verifier_notes=verifier_notes,
+    )
+
+    return _VerificationOutcome(result=updated_model, notes=notes, matched_span=matched_span)
+
+
+def _normalize_value(
+    numeric_value: Decimal | None,
+    text_value: str | None,
+    metric_payload: dict[str, Any] | None,
+) -> tuple[Decimal | None, str | None, list[str]]:
+    notes: list[str] = []
+    sanitized_text = text_value.strip() if text_value else None
+
+    extracted = _extract_decimal(sanitized_text) if sanitized_text else None
+    if numeric_value is None and extracted is not None:
+        numeric_value = extracted
+        notes.append("numeric value inferred from text")
+
+    is_percent_metric = _is_percent_metric(metric_payload, sanitized_text)
+
+    if numeric_value is not None and is_percent_metric:
+        if numeric_value <= 1:
+            numeric_value = numeric_value * Decimal("100")
+            notes.append("scaled fractional percent to 0-100 range")
+        if numeric_value < 0:
+            numeric_value = None
+            notes.append("discarded negative percent value")
+        elif numeric_value > 100:
+            notes.append("percent metric exceeds 100")
+        if sanitized_text:
+            sanitized_text = sanitized_text.replace("%", "").strip()
+    elif sanitized_text and extracted is not None and numeric_value is None:
+        numeric_value = extracted
+
+    if numeric_value is None and sanitized_text:
+        notes.append("text did not contain a parsable number")
+
+    normalized_text = sanitized_text
+    if numeric_value is not None and normalized_text is None:
+        normalized_text = str(numeric_value)
+
+    return numeric_value, normalized_text, notes
+
+
+def _match_value_in_evidence(
+    numeric_value: Decimal | None,
+    text_value: str | None,
+    evidence: Iterable[dict[str, Any]],
+    sections: dict[str, Section],
+    metric_payload: dict[str, Any] | None,
+) -> tuple[bool, str | None]:
+    tokens = _generate_value_tokens(numeric_value, text_value, metric_payload)
+    if not tokens:
+        return False, "no numeric tokens available for verification"
+
+    for entry in evidence or []:
+        span = entry.get("evidence_span")
+        if not span:
+            continue
+        section = sections.get(str(span.get("section_id")))
+        if section is None:
+            continue
+        start = max(int(span.get("start", 0)) - _SPAN_WINDOW, 0)
+        end = min(int(span.get("end", start)) + _SPAN_WINDOW, len(section.content))
+        snippet = section.content[start:end]
+        for token in tokens:
+            if token and token in snippet:
+                return True, f"value '{token}' confirmed near evidence span"
+
+    return False, "metric value not found near provided evidence span"
+
+
+def _detect_outlier(
+    numeric_value: Decimal | None,
+    metric_payload: dict[str, Any] | None,
+) -> tuple[bool, str | None]:
+    if numeric_value is None:
+        return False, None
+
+    metric_name = (metric_payload or {}).get("name")
+    if metric_name and "bleu" in metric_name.lower() and numeric_value > Decimal("100"):
+        return True, f"BLEU value {numeric_value} exceeds maximum expected range"
+
+    unit = (metric_payload or {}).get("unit")
+    if unit and unit.strip().lower() in {"%", "percent", "percentage"}:
+        if numeric_value < 0 or numeric_value > Decimal("100"):
+            return True, f"percent metric out of bounds: {numeric_value}"
+
+    return False, None
+
+
+def _generate_value_tokens(
+    numeric_value: Decimal | None,
+    text_value: str | None,
+    metric_payload: dict[str, Any] | None,
+) -> set[str]:
+    tokens: set[str] = set()
+    if text_value:
+        tokens.add(text_value)
+        tokens.add(text_value.replace("%", "").strip())
+
+    if numeric_value is not None:
+        float_value = float(numeric_value)
+        tokens.add(f"{float_value:.0f}")
+        tokens.add(f"{float_value:.1f}")
+        tokens.add(f"{float_value:.2f}")
+        if text_value and "%" in text_value:
+            tokens.add(f"{float_value:.0f}%")
+            tokens.add(f"{float_value:.1f}%")
+        unit = (metric_payload or {}).get("unit")
+        if unit and unit.strip().lower() in {"%", "percent", "percentage"}:
+            tokens.add(f"{float_value:.0f}%")
+            tokens.add(f"{float_value:.1f}%")
+            tokens.add(f"{float_value:.2f}%")
+        if float_value >= 1:
+            tokens.add(str(int(round(float_value))))
+        else:
+            tokens.add(f"{float_value:.3f}")
+
+    tokens = {token for token in tokens if token}
+    return tokens
+
+
+def _extract_decimal(text_value: str | None) -> Decimal | None:
+    if not text_value:
+        return None
+    cleaned = text_value.replace(",", "")
+    match = _VALUE_PATTERN.search(cleaned)
+    if not match:
+        return None
+    try:
+        return Decimal(match.group())
+    except Exception:
+        return None
+
+
+def _is_percent_metric(
+    metric_payload: dict[str, Any] | None,
+    text_value: str | None,
+) -> bool:
+    if metric_payload and metric_payload.get("unit"):
+        unit = metric_payload["unit"].strip().lower()
+        if unit in {"%", "percent", "percentage"}:
+            return True
+    if text_value and "%" in text_value:
+        return True
+    return False
+
+
+def _summary_result_to_model(paper_id: UUID, payload: dict[str, Any]) -> ResultCreate:
+    method_id = _parse_uuid(((payload.get("method") or {}).get("id")))
+    dataset_id = _parse_uuid(((payload.get("dataset") or {}).get("id")))
+    metric_id = _parse_uuid(((payload.get("metric") or {}).get("id")))
+    task_id = _parse_uuid(((payload.get("task") or {}).get("id")))
+
+    value_numeric = payload.get("value_numeric")
+    numeric_decimal = None
+    if value_numeric is not None:
+        numeric_decimal = Decimal(str(value_numeric))
+
+    return ResultCreate(
+        paper_id=paper_id,
+        method_id=method_id,
+        dataset_id=dataset_id,
+        metric_id=metric_id,
+        task_id=task_id,
+        split=payload.get("split"),
+        value_numeric=numeric_decimal,
+        value_text=payload.get("value_text"),
+        is_sota=bool(payload.get("is_sota")),
+        confidence=payload.get("confidence"),
+        evidence=list(payload.get("evidence") or []),
+        verified=payload.get("verified"),
+        verifier_notes=payload.get("verifier_notes"),
+    )
+
+
+def _serialize_result(
+    result,
+    *,
+    method_payloads: dict[UUID, dict[str, Any]],
+    dataset_payloads: dict[UUID, dict[str, Any]],
+    metric_payloads: dict[UUID, dict[str, Any]],
+    task_payloads: dict[UUID, dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "id": str(result.id),
+        "paper_id": str(result.paper_id),
+        "method": _clone_entity(method_payloads.get(result.method_id)),
+        "dataset": _clone_entity(dataset_payloads.get(result.dataset_id)),
+        "metric": _clone_entity(metric_payloads.get(result.metric_id)),
+        "task": _clone_entity(task_payloads.get(result.task_id)),
+        "split": result.split,
+        "value_numeric": float(result.value_numeric) if result.value_numeric is not None else None,
+        "value_text": result.value_text,
+        "is_sota": result.is_sota,
+        "confidence": result.confidence,
+        "evidence": result.evidence,
+        "verified": result.verified,
+        "verifier_notes": result.verifier_notes,
+        "created_at": result.created_at.isoformat(),
+        "updated_at": result.updated_at.isoformat(),
+    }
+
+
+def _build_entity_lookup(items: Iterable[dict[str, Any]]) -> dict[UUID, dict[str, Any]]:
+    lookup: dict[UUID, dict[str, Any]] = {}
+    for item in items:
+        identifier = _parse_uuid(item.get("id"))
+        if identifier is None:
+            continue
+        lookup[identifier] = copy.deepcopy(item)
+    return lookup
+
+
+def _clone_entity(entity: dict[str, Any] | None) -> dict[str, Any] | None:
+    if entity is None:
+        return None
+    return copy.deepcopy(entity)
+
+
+def _lookup_name(
+    lookup: dict[UUID, dict[str, Any]],
+    identifier: UUID | None,
+) -> str | None:
+    if identifier is None:
+        return None
+    entity = lookup.get(identifier)
+    if entity is None:
+        return None
+    return entity.get("name")
+
+
+def _parse_uuid(value: Any) -> UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except Exception:
+        return None
+
+
+def _merge_tiers(existing: Sequence[int] | Sequence[str], new: Sequence[int]) -> list[int]:
+    tier_set: set[int] = set()
+    for tier in existing:
+        try:
+            tier_set.add(int(tier))
+        except (TypeError, ValueError):
+            continue
+    tier_set.update(new)
+    return sorted(tier_set)
+
+
+def _combine_notes(notes: Iterable[str]) -> str | None:
+    cleaned = [note for note in notes if note]
+    if not cleaned:
+        return None
+    # Preserve order while removing duplicates
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for note in cleaned:
+        if note in seen:
+            continue
+        seen.add(note)
+        ordered.append(note)
+    return "; ".join(ordered)
+
+
+__all__ = ["run_tier3_verifier", "TIER_NAME"]
+

--- a/backend/app/services/ontology_store.py
+++ b/backend/app/services/ontology_store.py
@@ -186,12 +186,14 @@ async def replace_results(
                         value_text,
                         is_sota,
                         confidence,
-                        evidence
+                        evidence,
+                        verified,
+                        verifier_notes
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                     RETURNING id, paper_id, method_id, dataset_id, metric_id, task_id,
                               split, value_numeric, value_text, is_sota, confidence,
-                              evidence, created_at, updated_at
+                              evidence, verified, verifier_notes, created_at, updated_at
                     """,
                     result.paper_id,
                     result.method_id,
@@ -204,6 +206,8 @@ async def replace_results(
                     result.is_sota,
                     result.confidence,
                     result.evidence,
+                    result.verified,
+                    result.verifier_notes,
                 )
                 inserted.append(Result(**dict(row)))
     return inserted

--- a/backend/tests/test_tier1_extraction.py
+++ b/backend/tests/test_tier1_extraction.py
@@ -210,6 +210,8 @@ async def test_run_tier1_extraction_persists_results(monkeypatch: pytest.MonkeyP
                     is_sota=item.is_sota,
                     confidence=item.confidence,
                     evidence=item.evidence,
+                    verified=item.verified,
+                    verifier_notes=item.verifier_notes,
                     created_at=now,
                     updated_at=now,
                 )

--- a/backend/tests/test_tier3_verifier.py
+++ b/backend/tests/test_tier3_verifier.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.ontology import Result
+from app.models.paper import Paper
+from app.models.section import Section
+from app.services.extraction_tier3 import run_tier3_verifier
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _build_section(section_id: UUID, content: str) -> Section:
+    now = datetime.now(timezone.utc)
+    return Section.model_construct(
+        id=section_id,
+        paper_id=uuid4(),
+        title="Results",
+        content=content,
+        char_start=0,
+        char_end=len(content),
+        page_number=1,
+        snippet=content[:120],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _build_paper(paper_id: UUID) -> Paper:
+    now = datetime.now(timezone.utc)
+    return Paper.model_construct(
+        id=paper_id,
+        title="Verified Evaluations",
+        authors="Doe et al.",
+        venue="TestConf",
+        year=2024,
+        status="parsed",
+        file_path=None,
+        file_name="paper.pdf",
+        file_size=1024,
+        file_content_type="application/pdf",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _build_summary_payload(
+    *,
+    paper_id: UUID,
+    method_id: UUID,
+    dataset_id: UUID,
+    metric_id: UUID,
+    section_id: UUID,
+    value_numeric: float | None,
+    value_text: str | None,
+    confidence: float,
+    metric_name: str,
+    metric_unit: str | None = None,
+) -> dict:
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return {
+        "paper_id": str(paper_id),
+        "tiers": [1, 2],
+        "methods": [
+            {
+                "id": str(method_id),
+                "name": "Test Method",
+                "aliases": [],
+                "description": None,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ],
+        "datasets": [
+            {
+                "id": str(dataset_id),
+                "name": "Test Dataset",
+                "aliases": [],
+                "description": None,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ],
+        "metrics": [
+            {
+                "id": str(metric_id),
+                "name": metric_name,
+                "unit": metric_unit,
+                "aliases": [],
+                "description": None,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ],
+        "tasks": [],
+        "results": [
+            {
+                "id": str(uuid4()),
+                "paper_id": str(paper_id),
+                "method": {"id": str(method_id)},
+                "dataset": {"id": str(dataset_id)},
+                "metric": {"id": str(metric_id)},
+                "task": None,
+                "split": "test",
+                "value_numeric": value_numeric,
+                "value_text": value_text,
+                "is_sota": False,
+                "confidence": confidence,
+                "evidence": [
+                    {
+                        "tier": "llm_structurer",
+                        "evidence_span": {
+                            "section_id": str(section_id),
+                            "start": 10,
+                            "end": 60,
+                        },
+                    }
+                ],
+            }
+        ],
+        "claims": [],
+    }
+
+
+@pytest.mark.anyio("asyncio")
+async def test_tier3_verifier_confirms_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    paper_id = uuid4()
+    method_id = uuid4()
+    dataset_id = uuid4()
+    metric_id = uuid4()
+    section_id = uuid4()
+
+    paper = _build_paper(paper_id)
+    section = _build_section(section_id, "The model reaches 87% accuracy on the benchmark.")
+    summary = _build_summary_payload(
+        paper_id=paper_id,
+        method_id=method_id,
+        dataset_id=dataset_id,
+        metric_id=metric_id,
+        section_id=section_id,
+        value_numeric=0.87,
+        value_text="0.87",
+        confidence=0.7,
+        metric_name="Accuracy",
+        metric_unit="%",
+    )
+
+    stored_results: list[Result] = []
+
+    async def fake_get_paper(_: UUID) -> Paper:
+        return paper
+
+    async def fake_list_sections(*_: object, **__: object) -> list[Section]:
+        return [section]
+
+    async def fake_replace_results(_: UUID, models) -> list[Result]:
+        stored_results.clear()
+        now = datetime.now(timezone.utc)
+        for item in models:
+            result = Result.model_construct(
+                id=uuid4(),
+                paper_id=paper_id,
+                method_id=item.method_id,
+                dataset_id=item.dataset_id,
+                metric_id=item.metric_id,
+                task_id=item.task_id,
+                split=item.split,
+                value_numeric=item.value_numeric,
+                value_text=item.value_text,
+                is_sota=item.is_sota,
+                confidence=item.confidence,
+                evidence=item.evidence,
+                verified=item.verified,
+                verifier_notes=item.verifier_notes,
+                created_at=now,
+                updated_at=now,
+            )
+            stored_results.append(result)
+        return stored_results
+
+    monkeypatch.setattr("app.services.extraction_tier3.get_paper", fake_get_paper)
+    monkeypatch.setattr("app.services.extraction_tier3.list_sections", fake_list_sections)
+    monkeypatch.setattr("app.services.extraction_tier3.replace_results", fake_replace_results)
+
+    verified_summary = await run_tier3_verifier(paper_id, base_summary=summary)
+
+    assert stored_results
+    result = verified_summary["results"][0]
+    assert result["verified"] is True
+    assert pytest.approx(result["value_numeric"], rel=1e-5) == 87.0
+    assert result["confidence"] == pytest.approx(0.8, rel=1e-5)
+    assert "scaled fractional percent" in (result["verifier_notes"] or "")
+    assert verified_summary["audit_log"][0]["verified"] is True
+
+
+@pytest.mark.anyio("asyncio")
+async def test_tier3_verifier_flags_outlier(monkeypatch: pytest.MonkeyPatch) -> None:
+    paper_id = uuid4()
+    method_id = uuid4()
+    dataset_id = uuid4()
+    metric_id = uuid4()
+    section_id = uuid4()
+
+    paper = _build_paper(paper_id)
+    section = _build_section(section_id, "Reported BLEU score of 125 on validation.")
+    summary = _build_summary_payload(
+        paper_id=paper_id,
+        method_id=method_id,
+        dataset_id=dataset_id,
+        metric_id=metric_id,
+        section_id=section_id,
+        value_numeric=125,
+        value_text="125",
+        confidence=0.6,
+        metric_name="BLEU",
+    )
+
+    async def fake_get_paper(_: UUID) -> Paper:
+        return paper
+
+    async def fake_list_sections(*_: object, **__: object) -> list[Section]:
+        return [section]
+
+    async def fake_replace_results(_: UUID, models) -> list[Result]:
+        now = datetime.now(timezone.utc)
+        return [
+            Result.model_construct(
+                id=uuid4(),
+                paper_id=paper_id,
+                method_id=item.method_id,
+                dataset_id=item.dataset_id,
+                metric_id=item.metric_id,
+                task_id=item.task_id,
+                split=item.split,
+                value_numeric=item.value_numeric,
+                value_text=item.value_text,
+                is_sota=item.is_sota,
+                confidence=item.confidence,
+                evidence=item.evidence,
+                verified=item.verified,
+                verifier_notes=item.verifier_notes,
+                created_at=now,
+                updated_at=now,
+            )
+            for item in models
+        ]
+
+    monkeypatch.setattr("app.services.extraction_tier3.get_paper", fake_get_paper)
+    monkeypatch.setattr("app.services.extraction_tier3.list_sections", fake_list_sections)
+    monkeypatch.setattr("app.services.extraction_tier3.replace_results", fake_replace_results)
+
+    verified_summary = await run_tier3_verifier(paper_id, base_summary=summary)
+
+    result = verified_summary["results"][0]
+    assert result["verified"] is False
+    assert "BLEU value" in (result["verifier_notes"] or "")
+    assert verified_summary["audit_log"][0]["verified"] is False


### PR DESCRIPTION
## Summary
- add a Tier 3 verification service that cross-checks structured results against evidence, normalizes percent metrics, and records audit metadata
- persist verification status and notes via updated models, schema, and API flow so extraction tier 3 can be requested
- cover the verifier with new tests alongside existing tier 1 adjustments

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d00747ba148321ae21e15475a733ff