### PR TITLE
feat: add typed graph API and filters

### DIFF
--- a/Frontend/components/graph-explorer.tsx
+++ b/Frontend/components/graph-explorer.tsx
@@ -7,7 +7,7 @@ import {
   ArrowUpRight,
   Loader2,
   RefreshCw,
-  Target,
+  SlidersHorizontal,
 } from "lucide-react";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -17,17 +17,38 @@ const DEFAULT_DIMENSIONS = {
   height: 640,
 };
 
-const GRAPH_LIMIT = 75;
-const NEIGHBORHOOD_LIMIT = 60;
+const GRAPH_LIMIT = 150;
+const NEIGHBORHOOD_LIMIT = 75;
 
-type NodeType = "paper" | "concept";
+type NodeType = "method" | "dataset" | "metric" | "task";
+type RelationType = "proposes" | "evaluates_on" | "reports" | "compares";
+
+type GraphNodeLink = {
+  id: string;
+  label: string;
+  type: NodeType;
+  relation: RelationType;
+  weight: number;
+};
+
+type GraphEvidenceItem = {
+  paper_id: string;
+  paper_title?: string | null;
+  snippet?: string | null;
+  confidence: number;
+  relation: RelationType;
+};
 
 type GraphNodeData = {
   id: string;
   type: NodeType;
   label: string;
-  paper_id?: string | null;
-  concept_id?: string | null;
+  entity_id: string;
+  paper_count: number;
+  aliases: string[];
+  description?: string | null;
+  top_links: GraphNodeLink[];
+  evidence: GraphEvidenceItem[];
   metadata?: Record<string, unknown> | null;
 };
 
@@ -39,11 +60,10 @@ type GraphEdgeData = {
   id: string;
   source: string;
   target: string;
-  type: string;
-  paper_id?: string | null;
-  concept_id?: string | null;
-  related_concept_id?: string | null;
-  relation_id?: string | null;
+  type: RelationType;
+  weight: number;
+  paper_count: number;
+  average_confidence: number;
   metadata?: Record<string, unknown> | null;
 };
 
@@ -60,7 +80,11 @@ type GraphMeta = {
   has_more?: boolean | null;
   center_id?: string | null;
   center_type?: NodeType | null;
-  filters?: Record<string, unknown> | null;
+  filters?: {
+    types?: string[];
+    relations?: string[];
+    min_conf?: number;
+  } | null;
 };
 
 type GraphResponse = {
@@ -86,17 +110,31 @@ const INITIAL_GRAPH_STATE: GraphState = {
   edges: {},
 };
 
+const ALL_TYPES: NodeType[] = ["method", "dataset", "metric", "task"];
+const ALL_RELATIONS: RelationType[] = ["proposes", "evaluates_on", "reports", "compares"];
+
+const NODE_COLORS: Record<NodeType, string> = {
+  method: "#0ea5e9",
+  dataset: "#22c55e",
+  metric: "#8b5cf6",
+  task: "#f97316",
+};
+
+const EDGE_COLORS: Record<RelationType, string> = {
+  proposes: "#f97316",
+  evaluates_on: "#22c55e",
+  reports: "#8b5cf6",
+  compares: "#64748b",
+};
+
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const formatMetadataValue = (value: unknown): string => {
   if (value === null || value === undefined) {
     return "—";
   }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "bigint") {
-    return value.toString();
+  if (typeof value === "string" || typeof value === "number" || typeof value === "bigint") {
+    return String(value);
   }
   if (typeof value === "boolean") {
     return value ? "Yes" : "No";
@@ -108,31 +146,86 @@ const formatMetadataValue = (value: unknown): string => {
   }
 };
 
-const getPaperSubtitle = (metadata?: Record<string, unknown> | null): string => {
-  if (!metadata || typeof metadata !== "object") {
-    return "";
+const formatTypeLabel = (type: NodeType) => {
+  switch (type) {
+    case "method":
+      return "Method";
+    case "dataset":
+      return "Dataset";
+    case "metric":
+      return "Metric";
+    case "task":
+      return "Task";
+    default:
+      return type;
   }
-  const record = metadata as Record<string, unknown>;
-  const authors = record["authors"];
-  if (typeof authors === "string" && authors.trim().length > 0) {
-    return authors;
+};
+
+const formatRelationLabel = (relation: RelationType) => {
+  switch (relation) {
+    case "proposes":
+      return "Proposes";
+    case "evaluates_on":
+      return "Evaluates on";
+    case "reports":
+      return "Reports";
+    case "compares":
+      return "Compares";
+    default:
+      return relation;
   }
-  const venue = record["venue"];
-  if (typeof venue === "string" && venue.trim().length > 0) {
-    return venue;
+};
+
+const computeLayout = (nodes: GraphNodeData[], dimensions: LayoutDimensions): LayoutPositions => {
+  const width = Math.max(dimensions.width, DEFAULT_DIMENSIONS.width);
+  const height = Math.max(dimensions.height, DEFAULT_DIMENSIONS.height);
+  const marginX = Math.max(90, width * 0.08);
+  const marginY = Math.max(90, height * 0.08);
+  const availableWidth = Math.max(200, width - marginX * 2);
+  const availableHeight = Math.max(260, height - marginY * 2);
+
+  const positions: LayoutPositions = {};
+  const columnSpacing = ALL_TYPES.length > 1 ? availableWidth / (ALL_TYPES.length - 1) : 0;
+
+  ALL_TYPES.forEach((type, index) => {
+    const columnNodes = nodes.filter((node) => node.type === type);
+    if (columnNodes.length === 0) {
+      return;
+    }
+    const columnX = marginX + columnSpacing * index;
+    const rowSpacing = columnNodes.length > 1 ? Math.min(availableHeight / (columnNodes.length - 1), 180) : 0;
+
+    columnNodes.forEach((node, nodeIndex) => {
+      const y = columnNodes.length > 1 ? marginY + rowSpacing * nodeIndex : height / 2;
+      positions[node.id] = {
+        x: columnX,
+        y,
+      };
+    });
+  });
+
+  if (Object.keys(positions).length !== nodes.length) {
+    const fallbackRadius = Math.min(width, height) / 3;
+    nodes.forEach((node, index) => {
+      if (positions[node.id]) {
+        return;
+      }
+      const angle = (2 * Math.PI * index) / nodes.length;
+      positions[node.id] = {
+        x: width / 2 + fallbackRadius * Math.cos(angle),
+        y: height / 2 + fallbackRadius * Math.sin(angle),
+      };
+    });
   }
-  const year = record["year"];
-  if (typeof year === "number" || (typeof year === "string" && year.trim().length > 0)) {
-    return String(year);
-  }
-  return "";
+
+  return positions;
 };
 
 const getErrorMessage = (error: unknown): string => {
   if (axios.isAxiosError(error)) {
     const detail = error.response?.data as unknown;
-    if (detail && typeof detail === "object" && "detail" in detail && typeof detail.detail === "string") {
-      return detail.detail;
+    if (detail && typeof detail === "object" && "detail" in detail && typeof (detail as any).detail === "string") {
+      return (detail as any).detail;
     }
     if (typeof error.message === "string" && error.message.trim().length > 0) {
       return error.message;
@@ -142,82 +235,6 @@ const getErrorMessage = (error: unknown): string => {
     return error.message;
   }
   return "Unexpected error while fetching graph data.";
-};
-
-const computeLayout = (nodes: GraphNodeData[], dimensions: LayoutDimensions): LayoutPositions => {
-  const width = Math.max(dimensions.width, DEFAULT_DIMENSIONS.width);
-  const height = Math.max(dimensions.height, DEFAULT_DIMENSIONS.height);
-  const marginX = Math.max(120, width * 0.1);
-  const marginY = Math.max(120, height * 0.12);
-  const availableWidth = Math.max(200, width - marginX * 2);
-  const availableHeight = Math.max(220, height - marginY * 2);
-
-  const papers = nodes.filter((node) => node.type === "paper");
-  const concepts = nodes.filter((node) => node.type === "concept");
-
-  const positions: LayoutPositions = {};
-
-  if (papers.length === 0 && concepts.length === 0) {
-    return positions;
-  }
-
-  const estimatedColumns = papers.length > 0 ? Math.max(1, Math.floor(availableWidth / 240)) : 1;
-  const columnCount = papers.length > 0 ? Math.min(papers.length, estimatedColumns) : 1;
-  const rowCount = papers.length > 0 ? Math.ceil(papers.length / columnCount) : 1;
-  const columnSpacing = columnCount > 1 ? availableWidth / (columnCount - 1) : 0;
-  const rowSpacing = rowCount > 1 ? Math.min(availableHeight / (rowCount - 1), 280) : 0;
-
-  papers.forEach((paper, index) => {
-    const column = columnCount > 1 ? index % columnCount : 0;
-    const row = columnCount > 1 ? Math.floor(index / columnCount) : index;
-    const x = columnCount > 1 ? marginX + columnSpacing * column : width / 2;
-    const y = rowCount > 1 ? marginY + rowSpacing * row : height / 2;
-    positions[paper.id] = { x, y };
-  });
-
-  const groupedConcepts = new Map<string, GraphNodeData[]>();
-  concepts.forEach((concept) => {
-    const paperKey = concept.paper_id ? `paper:${concept.paper_id}` : null;
-    const key = paperKey && positions[paperKey] ? paperKey : `orphan:${concept.id}`;
-    const group = groupedConcepts.get(key);
-    if (group) {
-      group.push(concept);
-    } else {
-      groupedConcepts.set(key, [concept]);
-    }
-  });
-
-  groupedConcepts.forEach((group, key) => {
-    const center = positions[key] ?? { x: width / 2, y: height / 2 };
-    const perRing = Math.min(12, group.length);
-    const baseRadius = 110;
-    const ringGap = 70;
-
-    group.forEach((concept, index) => {
-      const ringIndex = perRing > 0 ? Math.floor(index / perRing) : 0;
-      const indexWithinRing = perRing > 0 ? index % perRing : index;
-      const radius = baseRadius + ringGap * ringIndex;
-      const angle = perRing === 1 ? -Math.PI / 2 : (2 * Math.PI * indexWithinRing) / perRing - Math.PI / 2;
-      const x = center.x + radius * Math.cos(angle);
-      const y = center.y + radius * Math.sin(angle);
-      const clampedX = clamp(x, marginX * 0.4, width - marginX * 0.4);
-      const clampedY = clamp(y, marginY * 0.4, height - marginY * 0.4);
-      positions[concept.id] = { x: clampedX, y: clampedY };
-    });
-  });
-
-  nodes.forEach((node, index) => {
-    if (!positions[node.id]) {
-      const gridColumns = Math.max(1, Math.floor(availableWidth / 200));
-      const col = index % gridColumns;
-      const row = Math.floor(index / gridColumns);
-      const x = marginX + (gridColumns > 1 ? (availableWidth / (gridColumns - 1 || 1)) * col : availableWidth / 2);
-      const y = marginY + Math.min(availableHeight, row * 160);
-      positions[node.id] = { x, y };
-    }
-  });
-
-  return positions;
 };
 
 const GraphExplorer = () => {
@@ -230,6 +247,10 @@ const GraphExplorer = () => {
   const [error, setError] = useState<string | null>(null);
   const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
   const [expandingNodeId, setExpandingNodeId] = useState<string | null>(null);
+  const [selectedTypes, setSelectedTypes] = useState<NodeType[]>(ALL_TYPES);
+  const [selectedRelations, setSelectedRelations] = useState<RelationType[]>(ALL_RELATIONS);
+  const [minConfidence, setMinConfidence] = useState<number>(0.6);
+  const [showEvidence, setShowEvidence] = useState<boolean>(false);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -257,53 +278,62 @@ const GraphExplorer = () => {
     return () => observer.disconnect();
   }, []);
 
-  const mergeGraphData = useCallback(
-    (payload: GraphResponse, options?: { reset?: boolean; allowSelect?: boolean }) => {
-      setGraph((previous) => {
-        const nextNodes = options?.reset ? {} : { ...previous.nodes };
-        payload.nodes.forEach((node) => {
-          nextNodes[node.data.id] = {
-            ...node.data,
-            metadata: node.data.metadata ?? undefined,
-          };
-        });
-
-        const nextEdges = options?.reset ? {} : { ...previous.edges };
-        payload.edges.forEach((edge) => {
-          nextEdges[edge.data.id] = {
-            ...edge.data,
-            metadata: edge.data.metadata ?? undefined,
-          };
-        });
-
-        return {
-          nodes: nextNodes,
-          edges: nextEdges,
+  const mergeGraphData = useCallback((payload: GraphResponse, options?: { reset?: boolean; allowSelect?: boolean }) => {
+    setGraph((previous) => {
+      const nextNodes = options?.reset ? {} : { ...previous.nodes };
+      payload.nodes.forEach((node) => {
+        nextNodes[node.data.id] = {
+          ...node.data,
+          aliases: node.data.aliases ?? [],
+          top_links: node.data.top_links ?? [],
+          evidence: node.data.evidence ?? [],
+          metadata: node.data.metadata ?? undefined,
         };
       });
 
-      setMeta(payload.meta);
-      setError(null);
+      const nextEdges = options?.reset ? {} : { ...previous.edges };
+      payload.edges.forEach((edge) => {
+        nextEdges[edge.data.id] = {
+          ...edge.data,
+          metadata: edge.data.metadata ?? undefined,
+        };
+      });
 
-      if (options?.allowSelect) {
-        setSelectedNodeId((current) => {
-          if (current && payload.nodes.some((node) => node.data.id === current)) {
-            return current;
-          }
-          return payload.meta.center_id ?? payload.nodes[0]?.data.id ?? current;
-        });
-      }
-    },
-    []
-  );
+      return {
+        nodes: nextNodes,
+        edges: nextEdges,
+      };
+    });
+
+    setMeta(payload.meta);
+    setError(null);
+
+    if (options?.allowSelect) {
+      setSelectedNodeId((current) => {
+        if (current && payload.nodes.some((node) => node.data.id === current)) {
+          return current;
+        }
+        return payload.meta.center_id ?? payload.nodes[0]?.data.id ?? current;
+      });
+    }
+  }, []);
+
+  const buildFilterParams = useCallback(() => {
+    return {
+      types: selectedTypes.join(","),
+      relations: selectedRelations.join(","),
+      min_conf: Number(minConfidence.toFixed(2)),
+    };
+  }, [minConfidence, selectedRelations, selectedTypes]);
 
   const loadOverview = useCallback(async () => {
     setIsInitialLoading(true);
     setError(null);
     setExpandedNodes({});
     try {
+      const params = { limit: GRAPH_LIMIT, ...buildFilterParams() };
       const response = await axios.get<GraphResponse>(`${API_BASE_URL}/api/graph/overview`, {
-        params: { limit: GRAPH_LIMIT },
+        params,
       });
       mergeGraphData(response.data, { reset: true, allowSelect: true });
     } catch (err) {
@@ -312,7 +342,7 @@ const GraphExplorer = () => {
       setIsInitialLoading(false);
       setExpandingNodeId(null);
     }
-  }, [mergeGraphData]);
+  }, [buildFilterParams, mergeGraphData]);
 
   useEffect(() => {
     void loadOverview();
@@ -325,6 +355,10 @@ const GraphExplorer = () => {
     }
   }, [graph.nodes, selectedNodeId]);
 
+  useEffect(() => {
+    setShowEvidence(false);
+  }, [selectedNodeId]);
+
   const expandNode = useCallback(
     async (nodeId: string) => {
       const node = graph.nodes[nodeId];
@@ -335,15 +369,16 @@ const GraphExplorer = () => {
         return;
       }
 
-      const targetId = node.type === "paper" ? node.paper_id : node.concept_id ?? node.paper_id;
+      const targetId = node.entity_id;
       if (!targetId) {
         return;
       }
 
       setExpandingNodeId(nodeId);
       try {
+        const params = { limit: NEIGHBORHOOD_LIMIT, ...buildFilterParams() };
         const response = await axios.get<GraphResponse>(`${API_BASE_URL}/api/graph/neighborhood/${targetId}`, {
-          params: { limit: NEIGHBORHOOD_LIMIT },
+          params,
         });
         mergeGraphData(response.data, { allowSelect: false });
         setExpandedNodes((previous) => ({
@@ -356,7 +391,7 @@ const GraphExplorer = () => {
         setExpandingNodeId((current) => (current === nodeId ? null : current));
       }
     },
-    [expandedNodes, graph.nodes, mergeGraphData]
+    [buildFilterParams, expandedNodes, graph.nodes, mergeGraphData]
   );
 
   const handleNodeSelect = useCallback(
@@ -384,13 +419,6 @@ const GraphExplorer = () => {
 
   const selectedNode = selectedNodeId ? graph.nodes[selectedNodeId] : undefined;
 
-  const selectedMetadataEntries = useMemo(() => {
-    if (!selectedNode || !selectedNode.metadata || typeof selectedNode.metadata !== "object") {
-      return [] as Array<[string, unknown]>;
-    }
-    return Object.entries(selectedNode.metadata as Record<string, unknown>);
-  }, [selectedNode]);
-
   const neighborSet = useMemo(() => {
     if (!selectedNodeId) {
       return new Set<string>();
@@ -406,59 +434,40 @@ const GraphExplorer = () => {
     return set;
   }, [edges, selectedNodeId]);
 
-  const connectedNodes = useMemo(() => {
-    if (!selectedNodeId) {
-      return [] as GraphNodeData[];
-    }
-    const connections: GraphNodeData[] = [];
-    neighborSet.forEach((id) => {
-      const node = graph.nodes[id];
-      if (node) {
-        connections.push(node);
-      }
-    });
-    return connections.sort((a, b) => a.label.localeCompare(b.label));
-  }, [graph.nodes, neighborSet, selectedNodeId]);
-
-  const stats = useMemo(
-    () => {
-      const paperCount = nodes.filter((node) => node.type === "paper").length;
-      const conceptCount = nodes.filter((node) => node.type === "concept").length;
-      return [
-        {
-          label: "Total nodes",
-          value: nodes.length,
-        },
-        {
-          label: "Concepts",
-          value: conceptCount,
-        },
-        {
-          label: "Papers",
-          value: paperCount,
-        },
-        {
-          label: "Edges",
-          value: edges.length,
-        },
-      ];
-    },
-    [edges.length, nodes]
-  );
+  const stats = useMemo(() => {
+    const methodCount = nodes.filter((node) => node.type === "method").length;
+    const datasetCount = nodes.filter((node) => node.type === "dataset").length;
+    const metricCount = nodes.filter((node) => node.type === "metric").length;
+    const taskCount = nodes.filter((node) => node.type === "task").length;
+    return [
+      { label: "Total nodes", value: nodes.length },
+      { label: "Methods", value: methodCount },
+      { label: "Datasets", value: datasetCount },
+      { label: "Edges", value: edges.length },
+      { label: "Metrics", value: metricCount },
+      { label: "Tasks", value: taskCount },
+    ];
+  }, [edges.length, nodes]);
 
   const graphSummary = useMemo(() => {
     if (!meta) {
       return null;
     }
     const pieces: string[] = [];
+    if (meta.paper_count) {
+      pieces.push(`${meta.paper_count} unique papers represented`);
+    }
     if (meta.filters) {
-      const filterEntries = Object.entries(meta.filters);
-      if (filterEntries.length > 0) {
-        pieces.push(
-          `Filters: ${filterEntries
-            .map(([key, value]) => `${key}=${formatMetadataValue(value)}`)
-            .join(", ")}`
-        );
+      const types = meta.filters.types?.join(", ");
+      const relations = meta.filters.relations?.join(", ");
+      if (types) {
+        pieces.push(`Types: ${types}`);
+      }
+      if (relations) {
+        pieces.push(`Relations: ${relations}`);
+      }
+      if (typeof meta.filters.min_conf === "number") {
+        pieces.push(`Min confidence: ${(meta.filters.min_conf * 100).toFixed(0)}%`);
       }
     }
     if (meta.has_more) {
@@ -477,21 +486,110 @@ const GraphExplorer = () => {
     }
   };
 
+  const toggleType = (type: NodeType) => {
+    setSelectedTypes((current) => {
+      if (current.includes(type)) {
+        if (current.length === 1) {
+          return current;
+        }
+        return current.filter((item) => item !== type);
+      }
+      const withType = [...current, type];
+      return ALL_TYPES.filter((item) => withType.includes(item));
+    });
+  };
+
+  const toggleRelation = (relation: RelationType) => {
+    setSelectedRelations((current) => {
+      if (current.includes(relation)) {
+        if (current.length === 1) {
+          return current;
+        }
+        return current.filter((item) => item !== relation);
+      }
+      const withRelation = [...current, relation];
+      return ALL_RELATIONS.filter((item) => withRelation.includes(item));
+    });
+  };
+
+  const handleConfidenceChange = (value: number) => {
+    setMinConfidence(clamp(Number(value), 0.5, 1));
+  };
+
   const hasGraphData = nodesWithPositions.length > 0;
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-      <div className="space-y-4">
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-5">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {stats.map((item) => (
-            <div
-              key={item.label}
-              className="rounded-lg border bg-card p-4 shadow-sm transition hover:shadow-md"
-            >
+            <div key={item.label} className="rounded-lg border bg-card p-4 shadow-sm transition hover:shadow-md">
               <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</p>
               <p className="mt-3 text-2xl font-semibold text-foreground">{item.value.toLocaleString()}</p>
             </div>
           ))}
+        </div>
+
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <SlidersHorizontal className="h-4 w-4" />
+              Filters
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+              <div className="flex items-center gap-2">
+                {ALL_TYPES.map((type) => {
+                  const isActive = selectedTypes.includes(type);
+                  return (
+                    <button
+                      key={type}
+                      type="button"
+                      onClick={() => toggleType(type)}
+                      className={`inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition ${
+                        isActive
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-border bg-background text-muted-foreground hover:bg-muted"
+                      }`}
+                    >
+                      {formatTypeLabel(type)}
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="uppercase tracking-wide">Confidence</span>
+                <input
+                  type="range"
+                  min={0.5}
+                  max={1}
+                  step={0.05}
+                  value={minConfidence}
+                  onChange={(event) => handleConfidenceChange(Number(event.target.value))}
+                  className="h-1 w-24 cursor-pointer"
+                />
+                <span className="font-semibold text-foreground">{(minConfidence * 100).toFixed(0)}%</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {ALL_RELATIONS.map((relation) => {
+                  const isActive = selectedRelations.includes(relation);
+                  return (
+                    <button
+                      key={relation}
+                      type="button"
+                      onClick={() => toggleRelation(relation)}
+                      className={`inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition ${
+                        isActive
+                          ? "border-secondary bg-secondary/10 text-secondary-foreground"
+                          : "border-border bg-background text-muted-foreground hover:bg-muted"
+                      }`}
+                    >
+                      {formatRelationLabel(relation)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
         </div>
 
         {error ? (
@@ -505,7 +603,7 @@ const GraphExplorer = () => {
           <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
             <div>
               <h2 className="text-lg font-semibold text-foreground">Knowledge graph</h2>
-              <p className="text-xs text-muted-foreground">Click nodes to expand their neighborhoods and inspect relationships.</p>
+              <p className="text-xs text-muted-foreground">Explore typed research entities and their structured relationships.</p>
             </div>
             <div className="flex items-center gap-2">
               <button
@@ -519,168 +617,94 @@ const GraphExplorer = () => {
               <button
                 type="button"
                 onClick={handleExpandSelected}
-                disabled={!selectedNodeId}
-                className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/40"
+                disabled={!selectedNodeId || expandingNodeId === selectedNodeId}
+                className="inline-flex items-center gap-2 rounded-md border border-primary bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                <Target className="h-4 w-4" />
-                Expand selection
+                <ArrowUpRight className="h-4 w-4" />
+                Expand selected
               </button>
             </div>
           </div>
 
-          {graphSummary ? (
-            <div className="border-b px-4 py-2 text-xs text-muted-foreground">{graphSummary}</div>
-          ) : null}
-
-          <div ref={containerRef} className="relative h-[640px] bg-muted/30">
+          <div ref={containerRef} className="relative h-[540px] w-full bg-background">
             {isInitialLoading ? (
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/70 text-sm font-medium text-muted-foreground">
-                <Loader2 className="h-5 w-5 animate-spin text-primary" />
-                Loading graph…
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : null}
 
-            {!isInitialLoading && !hasGraphData ? (
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
-                <ArrowUpRight className="h-5 w-5 text-muted-foreground/60" />
-                <p>No graph data available yet.</p>
-                <p>Use the ingestion pipeline to add papers and concepts.</p>
-              </div>
-            ) : null}
-
-            {!isInitialLoading && hasGraphData ? (
-              <svg
-                width={dimensions.width}
-                height={dimensions.height}
-                viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
-                className="block"
-              >
+            {hasGraphData ? (
+              <svg width={dimensions.width} height={dimensions.height} className="block">
                 <defs>
-                  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="65%">
-                    <stop offset="0%" stopColor="rgba(99, 102, 241, 0.35)" />
-                    <stop offset="100%" stopColor="rgba(99, 102, 241, 0)" />
-                  </radialGradient>
+                  <filter id="node-shadow" x="-50%" y="-50%" width="200%" height="200%">
+                    <feDropShadow dx="0" dy="2" stdDeviation="4" floodOpacity="0.18" />
+                  </filter>
                 </defs>
-                <g strokeLinecap="round" strokeLinejoin="round">
-                  {edges.map((edge) => {
-                    const source = positions[edge.source];
-                    const target = positions[edge.target];
-                    if (!source || !target) {
-                      return null;
-                    }
-                    const isActive =
-                      edge.source === selectedNodeId ||
-                      edge.target === selectedNodeId;
-                    const isRelation = edge.type !== "mentions";
-                    const stroke = isActive ? "#2563eb" : isRelation ? "#fb923c" : "#94a3b8";
-                    const opacity = isActive ? 0.95 : isRelation ? 0.85 : 0.6;
-                    const strokeWidth = isActive ? 2.8 : isRelation ? 2.4 : 1.6;
-                    return (
-                      <line
-                        key={edge.id}
-                        x1={source.x}
-                        y1={source.y}
-                        x2={target.x}
-                        y2={target.y}
-                        stroke={stroke}
-                        strokeWidth={strokeWidth}
-                        strokeOpacity={opacity}
-                      />
-                    );
-                  })}
-                </g>
+
+                {edges.map((edge) => {
+                  const source = graph.nodes[edge.source];
+                  const target = graph.nodes[edge.target];
+                  if (!source || !target) {
+                    return null;
+                  }
+                  const sourcePos = positions[source.id];
+                  const targetPos = positions[target.id];
+                  if (!sourcePos || !targetPos) {
+                    return null;
+                  }
+                  const strokeWidth = clamp(1 + Math.log(edge.weight + 1), 1.25, 4.5);
+                  const color = EDGE_COLORS[edge.type];
+                  const isActive = selectedNodeId && (edge.source === selectedNodeId || edge.target === selectedNodeId);
+                  return (
+                    <line
+                      key={edge.id}
+                      x1={sourcePos.x}
+                      y1={sourcePos.y}
+                      x2={targetPos.x}
+                      y2={targetPos.y}
+                      stroke={color}
+                      strokeWidth={strokeWidth}
+                      strokeOpacity={isActive ? 0.75 : 0.35}
+                      className="transition-opacity"
+                    />
+                  );
+                })}
 
                 {nodesWithPositions.map((node) => {
                   const isSelected = node.id === selectedNodeId;
                   const isNeighbor = neighborSet.has(node.id);
-                  const paper = node.type === "paper";
-                  const fill = paper ? "#0f172a" : "#0284c7";
-                  const stroke = isSelected ? "#6366f1" : paper ? "#1e293b" : "#0ea5e9";
-                  const textColor = paper ? "#f8fafc" : "#f0f9ff";
-                  const secondaryText = paper ? "#cbd5f5" : "#e0f2fe";
-                  const shadowOpacity = isSelected ? 0.8 : isNeighbor ? 0.4 : 0;
-                  const subtitle = paper ? getPaperSubtitle(node.metadata) : "";
-
+                  const color = NODE_COLORS[node.type];
+                  const radius = isSelected ? 18 : 14;
                   return (
-                    <g
-                      key={node.id}
-                      tabIndex={0}
-                      role="button"
-                      onClick={() => handleNodeSelect(node.id)}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          handleNodeSelect(node.id);
-                        }
-                      }}
-                      className="cursor-pointer focus:outline-none"
-                    >
-                      {shadowOpacity > 0 ? (
-                        <circle
-                          cx={node.x}
-                          cy={node.y}
-                          r={paper ? 48 : 42}
-                          fill="url(#nodeGlow)"
-                          fillOpacity={shadowOpacity}
-                        />
-                      ) : null}
-
-                      {paper ? (
-                        <rect
-                          x={node.x - 90}
-                          y={node.y - 40}
-                          width={180}
-                          height={80}
-                          rx={14}
-                          ry={14}
-                          fill={fill}
-                          stroke={stroke}
-                          strokeWidth={isSelected ? 3 : 2}
-                          opacity={isSelected ? 0.98 : isNeighbor ? 0.92 : 0.85}
-                          className="transition"
-                        />
-                      ) : (
-                        <circle
-                          cx={node.x}
-                          cy={node.y}
-                          r={28}
-                          fill={fill}
-                          stroke={stroke}
-                          strokeWidth={isSelected ? 3 : 2}
-                          opacity={isSelected ? 0.98 : isNeighbor ? 0.88 : 0.82}
-                          className="transition"
-                        />
-                      )}
-
+                    <g key={node.id} transform={`translate(${node.x}, ${node.y})`}>
+                      <circle
+                        r={radius}
+                        fill={color}
+                        fillOpacity={isSelected ? 1 : isNeighbor ? 0.9 : 0.75}
+                        stroke={isSelected ? "#1f2937" : "#0f172a"}
+                        strokeWidth={isSelected ? 3 : 2}
+                        filter="url(#node-shadow)"
+                        className="cursor-pointer transition-opacity"
+                        onClick={() => handleNodeSelect(node.id)}
+                      />
                       <text
-                        x={node.x}
-                        y={paper ? node.y - 6 : node.y + 4}
+                        x={0}
+                        y={radius + 18}
                         textAnchor="middle"
-                        fontSize={paper ? 13 : 12}
-                        fontWeight={isSelected ? 600 : 500}
-                        fill={textColor}
-                        style={{ pointerEvents: "none" }}
+                        className="select-none font-semibold text-slate-900"
+                        style={{ fontSize: "12px" }}
                       >
                         {node.label}
                       </text>
-
-                      {paper && subtitle ? (
-                        <text
-                          x={node.x}
-                          y={node.y + 18}
-                          textAnchor="middle"
-                          fontSize={11}
-                          fill={secondaryText}
-                          style={{ pointerEvents: "none" }}
-                        >
-                          {subtitle}
-                        </text>
-                      ) : null}
                     </g>
                   );
                 })}
               </svg>
-            ) : null}
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Adjust filters to load graph data.
+              </div>
+            )}
 
             {expandingNodeId ? (
               <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-2 rounded-full border border-primary/40 bg-background/80 px-4 py-1.5 text-xs font-medium text-primary shadow">
@@ -693,22 +717,34 @@ const GraphExplorer = () => {
 
         <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-card px-4 py-3 text-xs text-muted-foreground">
           <div className="flex items-center gap-2">
-            <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-sm bg-slate-900" />
-            Paper nodes
+            <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full" style={{ backgroundColor: NODE_COLORS.method }} />
+            Method nodes
           </div>
           <div className="flex items-center gap-2">
-            <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full bg-sky-500" />
-            Concept nodes
+            <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full" style={{ backgroundColor: NODE_COLORS.dataset }} />
+            Dataset nodes
           </div>
           <div className="flex items-center gap-2">
-            <span className="inline-flex h-3.5 w-1 rounded-full bg-slate-400" />
-            Mentions
+            <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full" style={{ backgroundColor: NODE_COLORS.metric }} />
+            Metric nodes
           </div>
           <div className="flex items-center gap-2">
-            <span className="inline-flex h-3.5 w-1 rounded-full bg-amber-400" />
-            Concept relations
+            <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full" style={{ backgroundColor: NODE_COLORS.task }} />
+            Task nodes
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-3.5 w-8 items-center justify-center rounded-full bg-muted text-[10px] font-semibold uppercase text-muted-foreground">
+              Edge
+            </span>
+            Edge color encodes relation type
           </div>
         </div>
+
+        {graphSummary ? (
+          <div className="rounded-lg border border-dashed bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+            {graphSummary}
+          </div>
+        ) : null}
       </div>
 
       <aside className="space-y-4">
@@ -718,28 +754,46 @@ const GraphExplorer = () => {
             <div className="mt-4 space-y-4 text-sm">
               <div>
                 <p className="text-xs font-medium uppercase tracking-wide text-primary">Label</p>
-                <p className="mt-1 font-semibold text-foreground">{selectedNode.label}</p>
+                <p className="mt-1 text-lg font-semibold text-foreground">{selectedNode.label}</p>
               </div>
 
-              <div className="grid gap-2">
-                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
-                  <span>Type</span>
-                  <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 font-medium capitalize text-primary">
-                    {selectedNode.type}
+              <div className="grid gap-2 text-xs text-muted-foreground">
+                <div className="flex items-center justify-between">
+                  <span className="uppercase tracking-wide">Type</span>
+                  <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 font-semibold text-primary">
+                    {formatTypeLabel(selectedNode.type)}
                   </span>
                 </div>
-                <div className="text-xs text-muted-foreground">
-                  {expandedNodes[selectedNode.id]
-                    ? "Neighborhood loaded"
-                    : "Click expand to load neighbors"}
+                <div className="flex items-center justify-between">
+                  <span className="uppercase tracking-wide">Used by</span>
+                  <span className="font-semibold text-foreground">{selectedNode.paper_count.toLocaleString()} papers</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="uppercase tracking-wide">Expanded</span>
+                  <span className="font-semibold text-foreground">
+                    {expandedNodes[selectedNode.id] ? "Yes" : "No"}
+                  </span>
                 </div>
               </div>
 
-              {selectedMetadataEntries.length > 0 ? (
+              {selectedNode.aliases && selectedNode.aliases.length > 0 ? (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Aliases</p>
+                  <div className="flex flex-wrap gap-1">
+                    {selectedNode.aliases.map((alias) => (
+                      <span key={alias} className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                        {alias}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+
+              {selectedNode.metadata && Object.keys(selectedNode.metadata).length > 0 ? (
                 <div className="space-y-2">
                   <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Metadata</p>
                   <dl className="grid gap-1 text-xs text-muted-foreground">
-                    {selectedMetadataEntries.map(([key, value]) => (
+                    {Object.entries(selectedNode.metadata).map(([key, value]) => (
                       <div key={key} className="flex justify-between gap-2">
                         <dt className="font-medium capitalize text-foreground/70">{key}</dt>
                         <dd className="text-right">{formatMetadataValue(value)}</dd>
@@ -749,44 +803,80 @@ const GraphExplorer = () => {
                 </div>
               ) : null}
 
-              {connectedNodes.length > 0 ? (
+              {selectedNode.top_links.length > 0 ? (
                 <div className="space-y-2">
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Connections</p>
-                  <ul className="space-y-1">
-                    {connectedNodes.map((node) => (
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Top linked nodes</p>
+                  <ul className="space-y-1 text-xs text-muted-foreground">
+                    {selectedNode.top_links.map((link) => (
                       <li
-                        key={node.id}
-                        className="flex items-center justify-between rounded-md border border-border/60 bg-muted/30 px-2 py-1 text-xs text-muted-foreground"
+                        key={link.id}
+                        className="flex items-center justify-between rounded-md border border-border/60 bg-muted/30 px-2 py-1"
                       >
-                        <span className="truncate font-medium text-foreground/80">{node.label}</span>
-                        <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          {node.type}
-                        </span>
+                        <div className="flex flex-col">
+                          <span className="font-semibold text-foreground/80">{link.label}</span>
+                          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {formatRelationLabel(link.relation)}
+                          </span>
+                        </div>
+                        <div className="text-right">
+                          <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            {formatTypeLabel(link.type)}
+                          </span>
+                          <div className="text-[10px] font-medium text-muted-foreground">
+                            Weight {link.weight.toFixed(2)}
+                          </div>
+                        </div>
                       </li>
                     ))}
                   </ul>
                 </div>
               ) : (
-                <p className="text-xs text-muted-foreground">
-                  Select a node to inspect its metadata and relationships.
-                </p>
+                <p className="text-xs text-muted-foreground">Expand the node to reveal its strongest connections.</p>
               )}
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Evidence</p>
+                  <button
+                    type="button"
+                    onClick={() => setShowEvidence((current) => !current)}
+                    className="text-xs font-medium text-primary underline-offset-2 hover:underline"
+                  >
+                    {showEvidence ? "Hide" : "Why?"}
+                  </button>
+                </div>
+                {showEvidence ? (
+                  selectedNode.evidence.length > 0 ? (
+                    <ul className="space-y-2 text-xs text-muted-foreground">
+                      {selectedNode.evidence.map((item, index) => (
+                        <li key={`${item.paper_id}-${index}`} className="rounded-md border border-border/60 bg-muted/30 p-2">
+                          <div className="flex items-center justify-between">
+                            <span className="font-semibold text-foreground/80">{item.paper_title ?? "Unknown paper"}</span>
+                            <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                              {formatRelationLabel(item.relation)} • {(item.confidence * 100).toFixed(0)}%
+                            </span>
+                          </div>
+                          {item.snippet ? <p className="mt-1 text-[13px] leading-snug text-foreground/80">“{item.snippet}”</p> : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">Evidence snippets will appear after expanding connected edges.</p>
+                  )
+                ) : null}
+              </div>
             </div>
           ) : (
-            <p className="mt-3 text-sm text-muted-foreground">
-              Select a node in the graph to view its metadata and connections.
-            </p>
+            <p className="mt-3 text-sm text-muted-foreground">Select a node in the graph to view its metadata and connections.</p>
           )}
         </div>
 
         <div className="rounded-lg border bg-card p-5 text-sm text-muted-foreground">
           <h3 className="text-base font-semibold text-foreground">How to explore</h3>
           <ul className="mt-3 space-y-2 text-sm">
-            <li>Click any node to highlight it and load its neighborhood.</li>
-            <li>Use the action buttons to reset the graph or force a fresh expansion.</li>
-            <li>
-              Concept-to-concept edges are highlighted in amber to differentiate them from paper associations.
-            </li>
+            <li>Toggle entity types and relation categories to focus on specific portions of the graph.</li>
+            <li>Adjust the confidence slider to hide uncertain relationships and highlight stronger evidence.</li>
+            <li>Click any node to load its neighborhood and inspect the top supporting papers via the “Why?” button.</li>
           </ul>
         </div>
       </aside>

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query
@@ -19,18 +19,38 @@ router = APIRouter(prefix="/graph", tags=["graph"])
 @router.get("/overview", response_model=GraphResponse)
 async def api_graph_overview(
     limit: int = Query(default=100, ge=1, le=500),
-    paper_id: Optional[UUID] = Query(default=None),
-    concept_type: Optional[str] = Query(default=None, min_length=1),
+    min_conf: float = Query(default=0.6, ge=0.0, le=1.0),
+    types: Optional[Sequence[str]] = Query(default=None),
+    relations: Optional[Sequence[str]] = Query(default=None),
 ) -> GraphResponse:
-    return await get_graph_overview(limit=limit, paper_id=paper_id, concept_type=concept_type)
+    try:
+        return await get_graph_overview(
+            limit=limit,
+            types=types,
+            relations=relations,
+            min_conf=min_conf,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/neighborhood/{node_id}", response_model=GraphResponse)
 async def api_graph_neighborhood(
     node_id: UUID,
     limit: int = Query(default=50, ge=1, le=500),
+    min_conf: float = Query(default=0.6, ge=0.0, le=1.0),
+    types: Optional[Sequence[str]] = Query(default=None),
+    relations: Optional[Sequence[str]] = Query(default=None),
 ) -> GraphResponse:
     try:
-        return await get_graph_neighborhood(node_id, limit=limit)
+        return await get_graph_neighborhood(
+            node_id,
+            limit=limit,
+            types=types,
+            relations=relations,
+            min_conf=min_conf,
+        )
     except GraphEntityNotFoundError as exc:  # pragma: no cover - handled for completeness
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/models/graph.py
+++ b/backend/app/models/graph.py
@@ -3,18 +3,39 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
-NodeType = Literal["paper", "concept"]
+NodeType = Literal["method", "dataset", "metric", "task"]
+RelationType = Literal["proposes", "evaluates_on", "reports", "compares"]
+
+
+class GraphNodeLink(BaseModel):
+    id: str
+    label: str
+    type: NodeType
+    relation: RelationType
+    weight: float
+
+
+class GraphEvidenceItem(BaseModel):
+    paper_id: UUID
+    paper_title: Optional[str] = None
+    snippet: Optional[str] = None
+    confidence: float
+    relation: RelationType
 
 
 class GraphNodeData(BaseModel):
     id: str
     type: NodeType
     label: str
-    paper_id: Optional[UUID] = None
-    concept_id: Optional[UUID] = None
+    entity_id: UUID
+    paper_count: int
+    aliases: List[str] = Field(default_factory=list)
+    description: Optional[str] = None
+    top_links: List[GraphNodeLink] = Field(default_factory=list)
+    evidence: List[GraphEvidenceItem] = Field(default_factory=list)
     metadata: Optional[Dict[str, Any]] = None
 
     class Config:
@@ -32,11 +53,10 @@ class GraphEdgeData(BaseModel):
     id: str
     source: str
     target: str
-    type: str
-    paper_id: Optional[UUID] = None
-    concept_id: Optional[UUID] = None
-    related_concept_id: Optional[UUID] = None
-    relation_id: Optional[UUID] = None
+    type: RelationType
+    weight: float
+    paper_count: int
+    average_confidence: float
     metadata: Optional[Dict[str, Any]] = None
 
     class Config:


### PR DESCRIPTION
## Summary
- implement typed graph aggregation for methods, datasets, metrics, and tasks with confidence-aware filters
- expand graph data models and tests to cover typed edges and configurable relations
- refresh the frontend graph explorer with filter controls, updated styling, and evidence display for nodes

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d017c137388321a8b649afb5ecf25b