### PR TITLE
Improve dataset detection heuristics for graph extraction

### DIFF
--- a/backend/app/services/extraction_tier1.py
+++ b/backend/app/services/extraction_tier1.py
@@ -45,7 +45,10 @@ RESULT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 EVALUATE_PATTERN = re.compile(
-    r"(?:evaluate(?:d)? on|tested on|trained on|measured on)\s+(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,})",
+    r"(?:evaluate(?:d)?|tested|trained|measured)"
+    r"(?:\s+[A-Za-z0-9\-]+){0,6}\s+on\s+"
+    r"(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,}?)(?=(?:[,.;]"
+    r"|\s+(?:and|with|for|using|achiev(?:es|ing)?|reports?|showing|compared|where)\b|$))",
     re.IGNORECASE,
 )
 PROPOSE_PATTERN = re.compile(

--- a/backend/tests/test_tier1_extraction.py
+++ b/backend/tests/test_tier1_extraction.py
@@ -78,6 +78,21 @@ def test_extract_signals_identifies_entities() -> None:
     assert result.evidence and result.evidence[0]["source"] == "section"
 
 
+def test_extract_signals_detects_dataset_with_intervening_words() -> None:
+    lexicon = load_mt_lexicon()
+    section = _build_section(
+        "We evaluate our new FooNet model on the CIFAR-10 dataset and report Accuracy = 92.3%."
+    )
+
+    artifacts = extract_signals([section], lexicon=lexicon)
+
+    dataset_names = {entity.name for entity in artifacts.datasets.values()}
+    assert any("CIFAR-10" in name for name in dataset_names)
+    assert any(
+        result.dataset_name and "CIFAR-10" in result.dataset_name for result in artifacts.results
+    )
+
+
 @pytest.mark.anyio("asyncio")
 async def test_run_tier1_extraction_persists_results(monkeypatch: pytest.MonkeyPatch) -> None:
     paper_id = uuid4()


### PR DESCRIPTION
## Summary
- broaden the dataset extraction regex to handle phrases like "evaluate our model on" so Tier-1 captures datasets more reliably
- add a regression test covering dataset detection when extra words appear between the evaluation verb and "on"

## Testing
- PYTHONPATH=backend pytest backend/tests/test_tier1_extraction.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d04ec45cd08321890882f9bf600029