### PR TITLE
Fix Tier-1 dataset filtering and JSON persistence

### DIFF
--- a/backend/app/services/extraction_tier1.py
+++ b/backend/app/services/extraction_tier1.py
@@ -45,7 +45,10 @@ RESULT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 EVALUATE_PATTERN = re.compile(
-    r"(?:evaluate(?:d)? on|tested on|trained on|measured on)\s+(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,})",
+    r"(?:evaluate(?:d)?|tested|trained|measured)"
+    r"(?:\s+[A-Za-z0-9\-]+){0,6}\s+on\s+"
+    r"(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,}?)(?=(?:[,.;]"
+    r"|\s+(?:and|with|for|using|achiev(?:es|ing)?|reports?|showing|compared|where)\b|$))",
     re.IGNORECASE,
 )
 PROPOSE_PATTERN = re.compile(
@@ -810,6 +813,24 @@ def _clean_dataset_name(name: str) -> str:
     cleaned = parts[0]
     cleaned = re.sub(r"[(),]", " ", cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if cleaned:
+        lowered = cleaned.lower()
+        if not any(ch.isdigit() for ch in cleaned):
+            disqualifiers = {
+                "model",
+                "method",
+                "approach",
+                "architecture",
+                "network",
+                "framework",
+                "system",
+                "technique",
+                "baseline",
+                "algorithm",
+            }
+            tokens = set(lowered.split())
+            if tokens.intersection(disqualifiers):
+                return ""
     return cleaned
 
 

--- a/backend/app/services/ontology_store.py
+++ b/backend/app/services/ontology_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Sequence
 from uuid import UUID
 
@@ -46,11 +47,11 @@ async def ensure_method(
         row = await conn.fetchrow(
             """
             INSERT INTO methods (name, aliases, description)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2::jsonb, $3)
             RETURNING id, name, aliases, description, created_at, updated_at
             """,
             cleaned,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
     return Method(**dict(row))
@@ -80,11 +81,11 @@ async def ensure_dataset(
         row = await conn.fetchrow(
             """
             INSERT INTO datasets (name, aliases, description)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2::jsonb, $3)
             RETURNING id, name, aliases, description, created_at, updated_at
             """,
             cleaned,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
     return Dataset(**dict(row))
@@ -115,12 +116,12 @@ async def ensure_metric(
         row = await conn.fetchrow(
             """
             INSERT INTO metrics (name, unit, aliases, description)
-            VALUES ($1, $2, $3, $4)
+            VALUES ($1, $2, $3::jsonb, $4)
             RETURNING id, name, unit, aliases, description, created_at, updated_at
             """,
             cleaned,
             unit,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
     return Metric(**dict(row))
@@ -150,11 +151,11 @@ async def ensure_task(
         row = await conn.fetchrow(
             """
             INSERT INTO tasks (name, aliases, description)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2::jsonb, $3)
             RETURNING id, name, aliases, description, created_at, updated_at
             """,
             cleaned,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
     return Task(**dict(row))
@@ -190,7 +191,7 @@ async def replace_results(
                         verified,
                         verifier_notes
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12, $13)
                     RETURNING id, paper_id, method_id, dataset_id, metric_id, task_id,
                               split, value_numeric, value_text, is_sota, confidence,
                               evidence, verified, verifier_notes, created_at, updated_at
@@ -205,7 +206,7 @@ async def replace_results(
                     result.value_text,
                     result.is_sota,
                     result.confidence,
-                    result.evidence,
+                    json.dumps(result.evidence),
                     result.verified,
                     result.verifier_notes,
                 )
@@ -229,14 +230,14 @@ async def replace_claims(
                 row = await conn.fetchrow(
                     """
                     INSERT INTO claims (paper_id, category, text, confidence, evidence)
-                    VALUES ($1, $2, $3, $4, $5)
+                    VALUES ($1, $2, $3, $4, $5::jsonb)
                     RETURNING id, paper_id, category, text, confidence, evidence, created_at, updated_at
                     """,
                     claim.paper_id,
                     claim.category,
                     claim.text,
                     claim.confidence,
-                    claim.evidence,
+                    json.dumps(claim.evidence),
                 )
                 inserted.append(Claim(**dict(row)))
     return inserted

--- a/backend/tests/test_tier1_extraction.py
+++ b/backend/tests/test_tier1_extraction.py
@@ -78,6 +78,33 @@ def test_extract_signals_identifies_entities() -> None:
     assert result.evidence and result.evidence[0]["source"] == "section"
 
 
+def test_extract_signals_detects_dataset_with_intervening_words() -> None:
+    lexicon = load_mt_lexicon()
+    section = _build_section(
+        "We evaluate our new FooNet model on the CIFAR-10 dataset and report Accuracy = 92.3%."
+    )
+
+    artifacts = extract_signals([section], lexicon=lexicon)
+
+    dataset_names = {entity.name for entity in artifacts.datasets.values()}
+    assert any("CIFAR-10" in name for name in dataset_names)
+    assert any(
+        result.dataset_name and "CIFAR-10" in result.dataset_name for result in artifacts.results
+    )
+
+
+def test_extract_signals_ignores_method_like_spans_for_datasets() -> None:
+    lexicon = load_mt_lexicon()
+    section = _build_section(
+        "We evaluate our Transformer model on the Transformer-based baseline before reporting results."
+    )
+
+    artifacts = extract_signals([section], lexicon=lexicon)
+
+    assert not artifacts.datasets
+    assert not artifacts.results
+
+
 @pytest.mark.anyio("asyncio")
 async def test_run_tier1_extraction_persists_results(monkeypatch: pytest.MonkeyPatch) -> None:
     paper_id = uuid4()


### PR DESCRIPTION
## Summary
- ensure ontology store writes JSONB columns using explicit casting to avoid asyncpg type errors
- tighten dataset cleaning heuristics to drop method-like spans picked up by the broader evaluation regex
- add a regression test so Transformer-style baselines no longer register as datasets

## Testing
- PYTHONPATH=backend pytest backend/tests/test_tier1_extraction.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d04ec45cd08321890882f9bf600029