### PR TITLE
Normalize ontology JSON columns before model validation

### DIFF
--- a/backend/app/services/extraction_tier1.py
+++ b/backend/app/services/extraction_tier1.py
@@ -45,7 +45,10 @@ RESULT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 EVALUATE_PATTERN = re.compile(
-    r"(?:evaluate(?:d)? on|tested on|trained on|measured on)\s+(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,})",
+    r"(?:evaluate(?:d)?|tested|trained|measured)"
+    r"(?:\s+[A-Za-z0-9\-]+){0,6}\s+on\s+"
+    r"(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,}?)(?=(?:[,.;]"
+    r"|\s+(?:and|with|for|using|achiev(?:es|ing)?|reports?|showing|compared|where)\b|$))",
     re.IGNORECASE,
 )
 PROPOSE_PATTERN = re.compile(
@@ -810,6 +813,24 @@ def _clean_dataset_name(name: str) -> str:
     cleaned = parts[0]
     cleaned = re.sub(r"[(),]", " ", cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if cleaned:
+        lowered = cleaned.lower()
+        if not any(ch.isdigit() for ch in cleaned):
+            disqualifiers = {
+                "model",
+                "method",
+                "approach",
+                "architecture",
+                "network",
+                "framework",
+                "system",
+                "technique",
+                "baseline",
+                "algorithm",
+            }
+            tokens = set(lowered.split())
+            if tokens.intersection(disqualifiers):
+                return ""
     return cleaned
 
 

--- a/backend/app/services/ontology_store.py
+++ b/backend/app/services/ontology_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Sequence
+from typing import Any
 from uuid import UUID
 
 from app.db.pool import get_pool
@@ -22,6 +24,72 @@ _METRIC_COLUMNS = "id, name, unit, aliases, description, created_at, updated_at"
 _TASK_COLUMNS = "id, name, aliases, description, created_at, updated_at"
 
 
+def _clean_aliases(raw_aliases: Iterable[str] | str | None) -> list[str]:
+    if raw_aliases is None:
+        candidates: list[Any] = []
+    elif isinstance(raw_aliases, str):
+        try:
+            decoded = json.loads(raw_aliases)
+        except json.JSONDecodeError:
+            candidates = [raw_aliases]
+        else:
+            if isinstance(decoded, list):
+                candidates = decoded
+            elif decoded is None:
+                candidates = []
+            else:
+                candidates = [decoded]
+    else:
+        candidates = list(raw_aliases)
+
+    cleaned = [
+        alias.strip()
+        for alias in candidates
+        if isinstance(alias, str) and alias.strip()
+    ]
+    return list(dict.fromkeys(cleaned))
+
+
+def _clean_evidence(raw_evidence: Any) -> list[dict[str, Any]]:
+    if raw_evidence is None:
+        return []
+    if isinstance(raw_evidence, list):
+        return [item for item in raw_evidence if isinstance(item, dict)]
+    if isinstance(raw_evidence, str):
+        try:
+            decoded = json.loads(raw_evidence)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(decoded, list):
+            return [item for item in decoded if isinstance(item, dict)]
+        return []
+    return []
+
+
+def _method_from_row(row: Any) -> Method:
+    payload = dict(row)
+    payload["aliases"] = _clean_aliases(payload.get("aliases"))
+    return Method(**payload)
+
+
+def _dataset_from_row(row: Any) -> Dataset:
+    payload = dict(row)
+    payload["aliases"] = _clean_aliases(payload.get("aliases"))
+    return Dataset(**payload)
+
+
+def _metric_from_row(row: Any) -> Metric:
+    payload = dict(row)
+    payload["aliases"] = _clean_aliases(payload.get("aliases"))
+    return Metric(**payload)
+
+
+def _task_from_row(row: Any) -> Task:
+    payload = dict(row)
+    payload["aliases"] = _clean_aliases(payload.get("aliases"))
+    return Task(**payload)
+
+
 async def ensure_method(
     name: str,
     *,
@@ -32,7 +100,7 @@ async def ensure_method(
     if not cleaned:
         raise ValueError("Method name cannot be empty")
 
-    alias_list = list(dict.fromkeys(alias.strip() for alias in (aliases or []) if alias))
+    alias_list = _clean_aliases(aliases)
 
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -41,19 +109,19 @@ async def ensure_method(
             cleaned,
         )
         if row:
-            return Method(**dict(row))
+            return _method_from_row(row)
 
         row = await conn.fetchrow(
             """
             INSERT INTO methods (name, aliases, description)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2::jsonb, $3)
             RETURNING id, name, aliases, description, created_at, updated_at
             """,
             cleaned,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
-    return Method(**dict(row))
+    return _method_from_row(row)
 
 
 async def ensure_dataset(
@@ -66,7 +134,7 @@ async def ensure_dataset(
     if not cleaned:
         raise ValueError("Dataset name cannot be empty")
 
-    alias_list = list(dict.fromkeys(alias.strip() for alias in (aliases or []) if alias))
+    alias_list = _clean_aliases(aliases)
 
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -75,19 +143,19 @@ async def ensure_dataset(
             cleaned,
         )
         if row:
-            return Dataset(**dict(row))
+            return _dataset_from_row(row)
 
         row = await conn.fetchrow(
             """
             INSERT INTO datasets (name, aliases, description)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2::jsonb, $3)
             RETURNING id, name, aliases, description, created_at, updated_at
             """,
             cleaned,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
-    return Dataset(**dict(row))
+    return _dataset_from_row(row)
 
 
 async def ensure_metric(
@@ -101,7 +169,7 @@ async def ensure_metric(
     if not cleaned:
         raise ValueError("Metric name cannot be empty")
 
-    alias_list = list(dict.fromkeys(alias.strip() for alias in (aliases or []) if alias))
+    alias_list = _clean_aliases(aliases)
 
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -110,20 +178,20 @@ async def ensure_metric(
             cleaned,
         )
         if row:
-            return Metric(**dict(row))
+            return _metric_from_row(row)
 
         row = await conn.fetchrow(
             """
             INSERT INTO metrics (name, unit, aliases, description)
-            VALUES ($1, $2, $3, $4)
+            VALUES ($1, $2, $3::jsonb, $4)
             RETURNING id, name, unit, aliases, description, created_at, updated_at
             """,
             cleaned,
             unit,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
-    return Metric(**dict(row))
+    return _metric_from_row(row)
 
 
 async def ensure_task(
@@ -136,7 +204,7 @@ async def ensure_task(
     if not cleaned:
         raise ValueError("Task name cannot be empty")
 
-    alias_list = list(dict.fromkeys(alias.strip() for alias in (aliases or []) if alias))
+    alias_list = _clean_aliases(aliases)
 
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -145,19 +213,19 @@ async def ensure_task(
             cleaned,
         )
         if row:
-            return Task(**dict(row))
+            return _task_from_row(row)
 
         row = await conn.fetchrow(
             """
             INSERT INTO tasks (name, aliases, description)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2::jsonb, $3)
             RETURNING id, name, aliases, description, created_at, updated_at
             """,
             cleaned,
-            alias_list,
+            json.dumps(alias_list),
             description,
         )
-    return Task(**dict(row))
+    return _task_from_row(row)
 
 
 async def replace_results(
@@ -190,7 +258,7 @@ async def replace_results(
                         verified,
                         verifier_notes
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12, $13)
                     RETURNING id, paper_id, method_id, dataset_id, metric_id, task_id,
                               split, value_numeric, value_text, is_sota, confidence,
                               evidence, verified, verifier_notes, created_at, updated_at
@@ -205,11 +273,13 @@ async def replace_results(
                     result.value_text,
                     result.is_sota,
                     result.confidence,
-                    result.evidence,
+                    json.dumps(result.evidence),
                     result.verified,
                     result.verifier_notes,
                 )
-                inserted.append(Result(**dict(row)))
+                payload = dict(row)
+                payload["evidence"] = _clean_evidence(payload.get("evidence"))
+                inserted.append(Result(**payload))
     return inserted
 
 
@@ -229,14 +299,16 @@ async def replace_claims(
                 row = await conn.fetchrow(
                     """
                     INSERT INTO claims (paper_id, category, text, confidence, evidence)
-                    VALUES ($1, $2, $3, $4, $5)
+                    VALUES ($1, $2, $3, $4, $5::jsonb)
                     RETURNING id, paper_id, category, text, confidence, evidence, created_at, updated_at
                     """,
                     claim.paper_id,
                     claim.category,
                     claim.text,
                     claim.confidence,
-                    claim.evidence,
+                    json.dumps(claim.evidence),
                 )
-                inserted.append(Claim(**dict(row)))
+                payload = dict(row)
+                payload["evidence"] = _clean_evidence(payload.get("evidence"))
+                inserted.append(Claim(**payload))
     return inserted

--- a/backend/tests/test_ontology_store_utils.py
+++ b/backend/tests/test_ontology_store_utils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.services.ontology_store import (
+    _clean_aliases,
+    _clean_evidence,
+    _method_from_row,
+)
+
+
+def test_clean_aliases_from_json_string() -> None:
+    raw = '["Transformer model", "Transformer architecture"]'
+    assert _clean_aliases(raw) == [
+        "Transformer model",
+        "Transformer architecture",
+    ]
+
+
+def test_clean_aliases_trims_and_deduplicates() -> None:
+    raw = [" Transformer model ", "Transformer model", ""]
+    assert _clean_aliases(raw) == ["Transformer model"]
+
+
+def test_method_from_row_coerces_alias_payload() -> None:
+    now = datetime.now(timezone.utc)
+    method = _method_from_row(
+        {
+            "id": uuid4(),
+            "name": "Transformer",
+            "aliases": '["Transformer model", "Transformer architecture"]',
+            "description": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    assert method.aliases == [
+        "Transformer model",
+        "Transformer architecture",
+    ]
+
+
+def test_clean_evidence_filters_non_dict_entries() -> None:
+    raw = '[{"text": "foo"}, {"span": 1}, "ignored"]'
+    assert _clean_evidence(raw) == [{"text": "foo"}, {"span": 1}]

--- a/backend/tests/test_tier1_extraction.py
+++ b/backend/tests/test_tier1_extraction.py
@@ -78,6 +78,33 @@ def test_extract_signals_identifies_entities() -> None:
     assert result.evidence and result.evidence[0]["source"] == "section"
 
 
+def test_extract_signals_detects_dataset_with_intervening_words() -> None:
+    lexicon = load_mt_lexicon()
+    section = _build_section(
+        "We evaluate our new FooNet model on the CIFAR-10 dataset and report Accuracy = 92.3%."
+    )
+
+    artifacts = extract_signals([section], lexicon=lexicon)
+
+    dataset_names = {entity.name for entity in artifacts.datasets.values()}
+    assert any("CIFAR-10" in name for name in dataset_names)
+    assert any(
+        result.dataset_name and "CIFAR-10" in result.dataset_name for result in artifacts.results
+    )
+
+
+def test_extract_signals_ignores_method_like_spans_for_datasets() -> None:
+    lexicon = load_mt_lexicon()
+    section = _build_section(
+        "We evaluate our Transformer model on the Transformer-based baseline before reporting results."
+    )
+
+    artifacts = extract_signals([section], lexicon=lexicon)
+
+    assert not artifacts.datasets
+    assert not artifacts.results
+
+
 @pytest.mark.anyio("asyncio")
 async def test_run_tier1_extraction_persists_results(monkeypatch: pytest.MonkeyPatch) -> None:
     paper_id = uuid4()


### PR DESCRIPTION
## Summary
- ensure ontology store writes JSONB columns using explicit casting to avoid asyncpg type errors
- tighten dataset cleaning heuristics to drop method-like spans picked up by the broader evaluation regex
- add a regression test so Transformer-style baselines no longer register as datasets
- normalise ontology aliases and evidence read from the database so legacy JSON strings stop breaking Pydantic validation, with unit coverage for the helpers

## Testing
- PYTHONPATH=backend pytest backend/tests/test_ontology_store_utils.py backend/tests/test_tier1_extraction.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d04ec45cd08321890882f9bf600029