### PR TITLE
Add ontology mention storage and enhance canonicalization signals

### DIFF
--- a/backend/app/db/migrations/0008_ontology_mentions.sql
+++ b/backend/app/db/migrations/0008_ontology_mentions.sql
@@ -1,0 +1,27 @@
+-- Mention-level storage for ontology canonicalization
+CREATE TABLE IF NOT EXISTS ontology_mentions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    resolution_type concept_resolution_type NOT NULL,
+    entity_id UUID NOT NULL,
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    section_id UUID REFERENCES sections(id) ON DELETE SET NULL,
+    surface TEXT NOT NULL,
+    normalized_surface TEXT NOT NULL,
+    mention_type TEXT,
+    context_snippet TEXT,
+    evidence_start INTEGER,
+    evidence_end INTEGER,
+    context_embedding DOUBLE PRECISION[],
+    first_seen_year INTEGER,
+    is_acronym BOOLEAN NOT NULL DEFAULT FALSE,
+    has_digit BOOLEAN NOT NULL DEFAULT FALSE,
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    source TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ontology_mentions_entity ON ontology_mentions (entity_id);
+CREATE INDEX IF NOT EXISTS idx_ontology_mentions_paper ON ontology_mentions (paper_id);
+CREATE INDEX IF NOT EXISTS idx_ontology_mentions_surface
+    ON ontology_mentions (resolution_type, normalized_surface);

--- a/backend/app/services/canonicalization.py
+++ b/backend/app/services/canonicalization.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 import math
-from typing import Dict, Iterable, Mapping, Sequence
+from typing import Dict, Iterable, Mapping, Optional, Sequence
 from uuid import UUID
 
 from app.core.config import settings
@@ -17,15 +17,29 @@ from app.models.ontology import (
     ConceptResolutionType,
 )
 from app.services.embeddings import EmbeddingBackend, build_embedding_backend
+@dataclass
+class _MentionSignal:
+    surface: str
+    normalized_surface: str
+    mention_type: Optional[str]
+    paper_id: Optional[UUID]
+    section_id: Optional[UUID]
+    start: Optional[int]
+    end: Optional[int]
+    first_seen_year: Optional[int]
+    is_acronym: bool
+    has_digit: bool
+    is_shared: bool
+    context_embedding: Optional[Sequence[float]]
 
 
-from typing import Optional
 @dataclass
 class _OntologyRecord:
     id: UUID
     name: str
     aliases: list[str]
     created_at: datetime
+    mentions: list[_MentionSignal]
 
 
 @dataclass(frozen=True)
@@ -121,6 +135,146 @@ def _select_canonical(group_ids: Sequence[UUID], records: Mapping[UUID, _Ontolog
     )
 
 
+def _generate_candidate_pairs(records: Sequence[_OntologyRecord]) -> set[tuple[UUID, UUID]]:
+    pairs: set[tuple[UUID, UUID]] = set()
+
+    def _add_pairs(ids: Sequence[UUID]) -> None:
+        unique = list(dict.fromkeys(ids))
+        for index, left in enumerate(unique):
+            for right in unique[index + 1 :]:
+                ordered = tuple(sorted((left, right), key=str))
+                if ordered[0] != ordered[1]:
+                    pairs.add(ordered)
+
+    alias_blocks: Dict[str, list[UUID]] = defaultdict(list)
+    for record in records:
+        for variant in [record.name, *record.aliases]:
+            key = _normalise_key(variant)
+            if key:
+                alias_blocks[key].append(record.id)
+    for ids in alias_blocks.values():
+        if len(ids) > 1:
+            _add_pairs(ids)
+
+    mention_blocks: Dict[str, list[UUID]] = defaultdict(list)
+    paper_blocks: Dict[UUID, list[UUID]] = defaultdict(list)
+    for record in records:
+        for mention in record.mentions:
+            if mention.normalized_surface:
+                mention_blocks[mention.normalized_surface].append(record.id)
+            if mention.paper_id:
+                paper_blocks[mention.paper_id].append(record.id)
+
+    for ids in mention_blocks.values():
+        if len(ids) > 1:
+            _add_pairs(ids)
+
+    for ids in paper_blocks.values():
+        if len(ids) > 1:
+            _add_pairs(ids)
+
+    if not pairs:
+        for index, left in enumerate(records):
+            for right in records[index + 1 :]:
+                ordered = tuple(sorted((left.id, right.id), key=str))
+                if ordered[0] != ordered[1]:
+                    pairs.add(ordered)
+
+    return pairs
+
+
+def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    if not left or not right:
+        return 0.0
+    numerator = sum(l * r for l, r in zip(left, right))
+    left_norm = math.sqrt(sum(l * l for l in left))
+    right_norm = math.sqrt(sum(r * r for r in right))
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    return float(max(-1.0, min(1.0, numerator / (left_norm * right_norm))))
+
+
+def _compute_mention_similarity(
+    left: _OntologyRecord,
+    right: _OntologyRecord,
+) -> float:
+    if not left.mentions or not right.mentions:
+        return 0.0
+
+    left_by_surface: Dict[str, list[_MentionSignal]] = defaultdict(list)
+    right_by_surface: Dict[str, list[_MentionSignal]] = defaultdict(list)
+    for mention in left.mentions:
+        if mention.normalized_surface:
+            left_by_surface[mention.normalized_surface].append(mention)
+    for mention in right.mentions:
+        if mention.normalized_surface:
+            right_by_surface[mention.normalized_surface].append(mention)
+
+    best = 0.0
+    shared_surfaces = set(left_by_surface.keys()).intersection(right_by_surface.keys())
+    for surface in shared_surfaces:
+        combined = left_by_surface[surface] + right_by_surface[surface]
+        candidate = 0.88
+        if not any(mention.is_shared for mention in combined):
+            candidate += 0.05
+        if any(mention.is_acronym for mention in combined):
+            candidate += 0.02
+        if any(mention.has_digit for mention in combined):
+            candidate += 0.01
+
+        years = [mention.first_seen_year for mention in combined if mention.first_seen_year]
+        if years:
+            diff = max(years) - min(years)
+            if diff <= 1:
+                candidate += 0.03
+            elif diff > 5:
+                candidate -= 0.05
+
+        context_scores: list[float] = []
+        for left_signal in left_by_surface[surface]:
+            if not left_signal.context_embedding:
+                continue
+            for right_signal in right_by_surface[surface]:
+                if not right_signal.context_embedding:
+                    continue
+                context_scores.append(
+                    _cosine_similarity(left_signal.context_embedding, right_signal.context_embedding)
+                )
+        if context_scores:
+            candidate = max(candidate, 0.75 + 0.2 * max(context_scores))
+
+        best = max(best, max(0.0, min(1.0, candidate)))
+
+    if best >= 0.9:
+        return best
+
+    shared_papers = {
+        mention.paper_id
+        for mention in left.mentions
+        if mention.paper_id is not None
+    }.intersection(
+        {
+            mention.paper_id
+            for mention in right.mentions
+            if mention.paper_id is not None
+        }
+    )
+    if shared_papers:
+        best = max(best, 0.82)
+
+    return max(0.0, min(1.0, best))
+
+
+def _score_pair(
+    left: _OntologyRecord,
+    right: _OntologyRecord,
+    embeddings: Dict[str, Sequence[float]],
+) -> float:
+    base = _compute_similarity(left.name, right.name, embeddings)
+    mention_score = _compute_mention_similarity(left, right)
+    return max(base, mention_score)
+
+
 def get_embedding_backend() -> EmbeddingBackend:
     global _embedding_backend
     if _embedding_backend is None:
@@ -139,7 +293,7 @@ async def canonicalize(
     async with pool.acquire() as conn:
         for resolution_type in selected:
             config = _TYPE_CONFIG[resolution_type]
-            records = await _load_records(conn, config)
+            records = await _load_records(conn, config, resolution_type)
             if not records:
                 summary.append(
                     CanonicalizationTypeReport(
@@ -170,27 +324,85 @@ async def canonicalize(
     return CanonicalizationReport(summary=summary)
 
 
-async def _load_records(conn, config: _TypeConfig) -> list[_OntologyRecord]:
-    query = f"SELECT id, name, aliases, created_at FROM {config.table}"
-    rows = await conn.fetch(query)
-    records: list[_OntologyRecord] = []
+async def _load_records(
+    conn,
+    config: _TypeConfig,
+    resolution_type: ConceptResolutionType,
+) -> list[_OntologyRecord]:
+    query = f"""
+        SELECT
+            base.id AS entity_id,
+            base.name AS entity_name,
+            base.aliases AS entity_aliases,
+            base.created_at AS entity_created_at,
+            mention.surface AS mention_surface,
+            mention.normalized_surface AS mention_normalized_surface,
+            mention.mention_type AS mention_type,
+            mention.paper_id AS mention_paper_id,
+            mention.section_id AS mention_section_id,
+            mention.evidence_start AS mention_start,
+            mention.evidence_end AS mention_end,
+            mention.first_seen_year AS mention_first_seen_year,
+            mention.is_acronym AS mention_is_acronym,
+            mention.has_digit AS mention_has_digit,
+            mention.is_shared AS mention_is_shared,
+            mention.context_embedding AS mention_context_embedding
+        FROM {config.table} AS base
+        LEFT JOIN ontology_mentions AS mention
+            ON mention.entity_id = base.id
+           AND mention.resolution_type = $1::concept_resolution_type
+        ORDER BY base.id
+    """
+    rows = await conn.fetch(query, resolution_type.value)
+    records: Dict[UUID, _OntologyRecord] = {}
     for row in rows:
-        name = _prepare_text(str(row["name"]))
-        alias_values = row.get("aliases", []) if isinstance(row, dict) else row["aliases"]
-        aliases = [
-            alias
-            for alias in (_prepare_text(str(value)) for value in alias_values or [])
-            if alias
-        ]
-        records.append(
-            _OntologyRecord(
-                id=row["id"],
+        payload = dict(row)
+        record_id: UUID = payload["entity_id"]
+        record = records.get(record_id)
+        if record is None:
+            name = _prepare_text(str(payload["entity_name"]))
+            alias_values = payload.get("entity_aliases") or []
+            aliases = [
+                alias
+                for alias in (_prepare_text(str(value)) for value in alias_values)
+                if alias
+            ]
+            record = _OntologyRecord(
+                id=record_id,
                 name=name,
                 aliases=aliases,
-                created_at=row["created_at"],
+                created_at=payload["entity_created_at"],
+                mentions=[],
             )
-        )
-    return records
+            records[record_id] = record
+
+        surface = payload.get("mention_surface")
+        if surface:
+            normalized_surface = payload.get("mention_normalized_surface") or _normalise_key(
+                str(surface)
+            )
+            raw_embedding = payload.get("mention_context_embedding")
+            vector: Optional[list[float]] = None
+            if isinstance(raw_embedding, (list, tuple)):
+                vector = [float(value) for value in raw_embedding]
+            record.mentions.append(
+                _MentionSignal(
+                    surface=_prepare_text(str(surface)),
+                    normalized_surface=normalized_surface,
+                    mention_type=payload.get("mention_type"),
+                    paper_id=payload.get("mention_paper_id"),
+                    section_id=payload.get("mention_section_id"),
+                    start=payload.get("mention_start"),
+                    end=payload.get("mention_end"),
+                    first_seen_year=payload.get("mention_first_seen_year"),
+                    is_acronym=bool(payload.get("mention_is_acronym")),
+                    has_digit=bool(payload.get("mention_has_digit")),
+                    is_shared=bool(payload.get("mention_is_shared")),
+                    context_embedding=vector,
+                )
+            )
+
+    return list(records.values())
 
 
 async def _compute_canonicalization(
@@ -228,13 +440,15 @@ async def _compute_canonicalization(
             uf.union(base, other)
 
     threshold = _SIMILARITY_THRESHOLDS[resolution_type]
-    for idx, left in enumerate(records):
-        for right in records[idx + 1 :]:
-            if uf.find(left.id) == uf.find(right.id):
-                continue
-            score = _compute_similarity(left.name, right.name, embeddings)
-            if score >= threshold:
-                uf.union(left.id, right.id)
+    candidate_pairs = _generate_candidate_pairs(records)
+    for left_id, right_id in candidate_pairs:
+        if uf.find(left_id) == uf.find(right_id):
+            continue
+        left_record = record_by_id[left_id]
+        right_record = record_by_id[right_id]
+        score = _score_pair(left_record, right_record, embeddings)
+        if score >= threshold:
+            uf.union(left_id, right_id)
 
     groups: Dict[UUID, list[UUID]] = defaultdict(list)
     for record in records:

--- a/backend/app/services/mentions.py
+++ b/backend/app/services/mentions.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.ontology import ConceptResolutionType
+
+
+@dataclass
+class MentionObservation:
+    resolution_type: ConceptResolutionType
+    entity_id: UUID
+    paper_id: UUID
+    section_id: Optional[UUID]
+    surface: str
+    mention_type: Optional[str]
+    snippet: Optional[str]
+    start: Optional[int]
+    end: Optional[int]
+    source: Optional[str]
+    first_seen_year: Optional[int]
+
+
+def _normalize_surface(value: str) -> str:
+    normalized = " ".join(value.strip().casefold().split())
+    return normalized
+
+
+def _is_acronym(surface: str) -> bool:
+    cleaned = surface.strip()
+    if len(cleaned) < 2 or len(cleaned) > 16:
+        return False
+    alpha_chars = [ch for ch in cleaned if ch.isalpha()]
+    if not alpha_chars:
+        return False
+    return cleaned.upper() == cleaned and all(ch.isalpha() for ch in cleaned if ch.isalpha())
+
+
+def _has_digit(surface: str) -> bool:
+    return any(ch.isdigit() for ch in surface)
+
+
+def _build_context_embedding(snippet: Optional[str]) -> Optional[list[float]]:
+    if not snippet:
+        return None
+    length = float(len(snippet))
+    if length == 0:
+        return [0.0, 0.0, 0.0]
+    uppercase = sum(1 for ch in snippet if ch.isupper())
+    digits = sum(1 for ch in snippet if ch.isdigit())
+    spaces = sum(1 for ch in snippet if ch.isspace())
+    return [
+        length,
+        float(uppercase) / length,
+        float(digits + spaces) / length,
+    ]
+
+
+def _mark_shared_flags(records: Sequence[dict[str, object]]) -> None:
+    surface_index: dict[tuple[str, str], set[UUID]] = {}
+    for record in records:
+        normalized_surface = record.get("normalized_surface")
+        resolution_type = record.get("resolution_type")
+        entity_id = record.get("entity_id")
+        if not isinstance(normalized_surface, str) or not normalized_surface:
+            continue
+        if not isinstance(resolution_type, str) or not isinstance(entity_id, UUID):
+            continue
+        key = (resolution_type, normalized_surface)
+        surface_index.setdefault(key, set()).add(entity_id)
+
+    for record in records:
+        normalized_surface = record.get("normalized_surface")
+        resolution_type = record.get("resolution_type")
+        if not isinstance(normalized_surface, str) or not normalized_surface:
+            record["is_shared"] = False
+            continue
+        if not isinstance(resolution_type, str):
+            record["is_shared"] = False
+            continue
+        key = (resolution_type, normalized_surface)
+        record["is_shared"] = len(surface_index.get(key, set())) > 1
+
+
+async def replace_mentions_for_paper(
+    paper_id: UUID, mentions: Iterable[MentionObservation]
+) -> None:
+    prepared: list[dict[str, object]] = []
+    for mention in mentions:
+        surface = (mention.surface or "").strip()
+        if not surface:
+            continue
+        normalized_surface = _normalize_surface(surface)
+        record = {
+            "resolution_type": mention.resolution_type.value,
+            "entity_id": mention.entity_id,
+            "paper_id": mention.paper_id,
+            "section_id": mention.section_id,
+            "surface": surface,
+            "normalized_surface": normalized_surface,
+            "mention_type": mention.mention_type,
+            "context_snippet": mention.snippet,
+            "evidence_start": mention.start,
+            "evidence_end": mention.end,
+            "context_embedding": _build_context_embedding(mention.snippet),
+            "first_seen_year": mention.first_seen_year,
+            "is_acronym": _is_acronym(surface),
+            "has_digit": _has_digit(surface),
+            "is_shared": False,  # set below
+            "source": mention.source,
+        }
+        prepared.append(record)
+
+    if not prepared:
+        pool = get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM ontology_mentions WHERE paper_id = $1", paper_id)
+        return
+
+    _mark_shared_flags(prepared)
+
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("DELETE FROM ontology_mentions WHERE paper_id = $1", paper_id)
+            await conn.executemany(
+                """
+                INSERT INTO ontology_mentions (
+                    resolution_type,
+                    entity_id,
+                    paper_id,
+                    section_id,
+                    surface,
+                    normalized_surface,
+                    mention_type,
+                    context_snippet,
+                    evidence_start,
+                    evidence_end,
+                    context_embedding,
+                    first_seen_year,
+                    is_acronym,
+                    has_digit,
+                    is_shared,
+                    source
+                )
+                VALUES (
+                    $1::concept_resolution_type,
+                    $2,
+                    $3,
+                    $4,
+                    $5,
+                    $6,
+                    $7,
+                    $8,
+                    $9,
+                    $10,
+                    $11,
+                    $12,
+                    $13,
+                    $14,
+                    $15,
+                    $16
+                )
+                """,
+                [
+                    (
+                        record["resolution_type"],
+                        record["entity_id"],
+                        record["paper_id"],
+                        record["section_id"],
+                        record["surface"],
+                        record["normalized_surface"],
+                        record.get("mention_type"),
+                        record.get("context_snippet"),
+                        record.get("evidence_start"),
+                        record.get("evidence_end"),
+                        record.get("context_embedding"),
+                        record.get("first_seen_year"),
+                        record.get("is_acronym", False),
+                        record.get("has_digit", False),
+                        record.get("is_shared", False),
+                        record.get("source"),
+                    )
+                    for record in prepared
+                ],
+            )


### PR DESCRIPTION
## Summary
- create an `ontology_mentions` table for mention-level signals and a service helper to populate it
- extend tier-1 extraction to capture mention spans, derive metadata, and persist mention observations per ontology entity
- enrich canonicalization loading and scoring to incorporate mention-based blocking and tests that verify merge sensitivity to mention signals

## Testing
- `pytest backend/tests/test_canonicalization_service.py backend/tests/test_tier1_extraction.py` *(fails: missing fastapi dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8679077e0832195100174c7774c72