### PR TITLE
feat: add adjudication support to canonicalization

### DIFF
--- a/backend/app/services/canonicalization.py
+++ b/backend/app/services/canonicalization.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 import math
-from typing import Dict, Iterable, Mapping, Sequence
+from typing import Dict, Mapping, Optional, Protocol, Sequence, Tuple
 from uuid import UUID
 
 from app.core.config import settings
@@ -17,9 +17,6 @@ from app.models.ontology import (
     ConceptResolutionType,
 )
 from app.services.embeddings import EmbeddingBackend, build_embedding_backend
-
-
-from typing import Optional
 @dataclass
 class _OntologyRecord:
     id: UUID
@@ -32,6 +29,31 @@ class _OntologyRecord:
 class _TypeConfig:
     table: str
     fk_column: str
+
+
+@dataclass(frozen=True)
+class CanonicalizationAdjudicationRequest:
+    resolution_type: ConceptResolutionType
+    left_id: UUID
+    left_name: str
+    left_aliases: Sequence[str]
+    right_id: UUID
+    right_name: str
+    right_aliases: Sequence[str]
+    similarity: float
+
+
+@dataclass(frozen=True)
+class CanonicalizationAdjudicationResult:
+    approved: bool
+    rationale: str
+
+
+class CanonicalizationAdjudicator(Protocol):
+    async def adjudicate(
+        self, request: CanonicalizationAdjudicationRequest
+    ) -> CanonicalizationAdjudicationResult:
+        ...
 
 
 _TYPE_CONFIG: Dict[ConceptResolutionType, _TypeConfig] = {
@@ -47,6 +69,14 @@ _SIMILARITY_THRESHOLDS: Dict[ConceptResolutionType, float] = {
     ConceptResolutionType.DATASET: 0.82,
     ConceptResolutionType.METRIC: 0.90,
     ConceptResolutionType.TASK: 0.80,
+}
+
+
+_SIMILARITY_BORDERLINE_WINDOWS: Dict[ConceptResolutionType, Tuple[float, float]] = {
+    ConceptResolutionType.METHOD: (0.80, 0.85),
+    ConceptResolutionType.DATASET: (0.78, 0.82),
+    ConceptResolutionType.METRIC: (0.86, 0.90),
+    ConceptResolutionType.TASK: (0.76, 0.80),
 }
 
 
@@ -132,6 +162,7 @@ def get_embedding_backend() -> EmbeddingBackend:
 
 async def canonicalize(
     types: Optional[Sequence[ConceptResolutionType]] = None,
+    adjudicator: Optional[CanonicalizationAdjudicator] = None,
 ) -> CanonicalizationReport:
     selected = list(types) if types else list(_TYPE_CONFIG.keys())
     pool = get_pool()
@@ -152,7 +183,11 @@ async def canonicalize(
                 )
                 continue
 
-            computation = await _compute_canonicalization(records, resolution_type)
+            computation = await _compute_canonicalization(
+                records,
+                resolution_type,
+                adjudicator=adjudicator,
+            )
             async with conn.transaction():
                 await _persist_concept_resolutions(conn, resolution_type, computation)
                 await _update_aliases(conn, config, computation)
@@ -196,6 +231,7 @@ async def _load_records(conn, config: _TypeConfig) -> list[_OntologyRecord]:
 async def _compute_canonicalization(
     records: Sequence[_OntologyRecord],
     resolution_type: ConceptResolutionType,
+    adjudicator: Optional[CanonicalizationAdjudicator] = None,
 ) -> _CanonicalizationComputation:
     record_by_id: Dict[UUID, _OntologyRecord] = {record.id: record for record in records}
     texts: list[str] = []
@@ -228,12 +264,43 @@ async def _compute_canonicalization(
             uf.union(base, other)
 
     threshold = _SIMILARITY_THRESHOLDS[resolution_type]
+    borderline_window = _SIMILARITY_BORDERLINE_WINDOWS.get(resolution_type)
+    pending_adjudications: list[tuple[_OntologyRecord, _OntologyRecord, float]] = []
     for idx, left in enumerate(records):
         for right in records[idx + 1 :]:
             if uf.find(left.id) == uf.find(right.id):
                 continue
             score = _compute_similarity(left.name, right.name, embeddings)
+            is_borderline = False
+            if borderline_window:
+                lower, upper = borderline_window
+                if lower <= score <= upper:
+                    is_borderline = True
+            if is_borderline:
+                pending_adjudications.append((left, right, score))
+                continue
             if score >= threshold:
+                uf.union(left.id, right.id)
+
+    if pending_adjudications:
+        for left, right, score in pending_adjudications:
+            if uf.find(left.id) == uf.find(right.id):
+                continue
+            if adjudicator is None:
+                uf.union(left.id, right.id)
+                continue
+            request = CanonicalizationAdjudicationRequest(
+                resolution_type=resolution_type,
+                left_id=left.id,
+                left_name=left.name,
+                left_aliases=tuple(left.aliases),
+                right_id=right.id,
+                right_name=right.name,
+                right_aliases=tuple(right.aliases),
+                similarity=float(score),
+            )
+            result = await adjudicator.adjudicate(request)
+            if result.approved:
                 uf.union(left.id, right.id)
 
     groups: Dict[UUID, list[UUID]] = defaultdict(list)

--- a/backend/tests/test_canonicalization_service.py
+++ b/backend/tests/test_canonicalization_service.py
@@ -8,6 +8,10 @@ import pytest
 
 from app.models.ontology import ConceptResolutionType
 from app.services import canonicalization as canonicalization_service
+from app.services.canonicalization import (
+    CanonicalizationAdjudicationRequest,
+    CanonicalizationAdjudicationResult,
+)
 
 
 METHOD_A = UUID("11111111-1111-1111-1111-111111111111")
@@ -176,3 +180,90 @@ async def _run_canonicalize_service_merges_methods(monkeypatch: pytest.MonkeyPat
     method_ids = {row["method_id"] for row in conn.results}
     assert METHOD_B not in method_ids
     assert METHOD_A in method_ids
+
+
+class FakeAdjudicator:
+    def __init__(self, *, approved: bool) -> None:
+        self._approved = approved
+        self.requests: list[CanonicalizationAdjudicationRequest] = []
+
+    async def adjudicate(
+        self, request: CanonicalizationAdjudicationRequest
+    ) -> CanonicalizationAdjudicationResult:
+        self.requests.append(request)
+        rationale = "approved" if self._approved else "denied"
+        return CanonicalizationAdjudicationResult(
+            approved=self._approved,
+            rationale=f"Fake adjudicator {rationale}",
+        )
+
+
+def test_canonicalize_service_borderline_requires_adjudicator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(_run_canonicalize_service_borderline(monkeypatch, None, True))
+
+
+def test_canonicalize_service_borderline_adjudicator_approves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(
+        _run_canonicalize_service_borderline(
+            monkeypatch,
+            FakeAdjudicator(approved=True),
+            True,
+        )
+    )
+
+
+def test_canonicalize_service_borderline_adjudicator_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(
+        _run_canonicalize_service_borderline(
+            monkeypatch,
+            FakeAdjudicator(approved=False),
+            False,
+        )
+    )
+
+
+async def _run_canonicalize_service_borderline(
+    monkeypatch: pytest.MonkeyPatch,
+    adjudicator: FakeAdjudicator | None,
+    expect_merge: bool,
+) -> None:
+    backend = FakeEmbeddingBackend()
+    conn = FakeCanonicalizationConnection()
+    pool = FakePool(conn)
+
+    monkeypatch.setattr(canonicalization_service, "_embedding_backend", backend, raising=False)
+    monkeypatch.setattr(canonicalization_service, "get_pool", lambda: pool)
+    monkeypatch.setitem(
+        canonicalization_service._SIMILARITY_BORDERLINE_WINDOWS,
+        ConceptResolutionType.METHOD,
+        (0.0, 1.0),
+    )
+
+    report = await canonicalization_service.canonicalize(
+        [ConceptResolutionType.METHOD],
+        adjudicator=adjudicator,
+    )
+
+    assert report.summary
+    entry = report.summary[0]
+    assert entry.resolution_type == ConceptResolutionType.METHOD
+    if expect_merge:
+        assert entry.after == 2
+        assert entry.merges == 1
+    else:
+        assert entry.after == 3
+        assert entry.merges == 0
+
+    if adjudicator is not None:
+        assert adjudicator.requests
+        ids = {
+            (request.left_id, request.right_id)
+            for request in adjudicator.requests
+        }
+        assert (METHOD_A, METHOD_B) in ids or (METHOD_B, METHOD_A) in ids


### PR DESCRIPTION
## Summary
- add adjudication request/result dataclasses and configurable borderline windows for canonicalization
- integrate an optional adjudicator to decide on borderline merges during canonicalization
- extend canonicalization service tests with fake adjudicator coverage for approval and denial paths

## Testing
- pytest backend/tests/test_canonicalization_service.py *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b6c6c96c83218611d95c0c1ef7a7