### PR TITLE
Trigger canonicalization after parse

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,7 @@ class Settings(BaseSettings):
 
     # Canonicalization
     canonicalization_mapping_version: int = Field(default=1)
+    auto_canonicalize_after_parse: bool = Field(default=False)
 
     # Tier-2 LLM
     openai_api_key: Optional[str] = Field(default=None)


### PR DESCRIPTION
## Summary
- add a configuration flag to control whether parse_pdf_task runs canonicalization automatically
- invoke canonicalization when the flag is enabled and ensure failures are logged without failing the parse task
- extend the pipeline tests to confirm canonicalization is triggered when enabled

## Testing
- pytest backend/tests/test_pipeline.py *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68d8e65ffa388321acabef586c44bc04