### PR TITLE
Fix missing Tuple import in canonicalization service

### DIFF
--- a/backend/app/services/canonicalization.py
+++ b/backend/app/services/canonicalization.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 import math
-from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple
 from uuid import UUID
 
 from app.core.config import settings


### PR DESCRIPTION
## Summary
- add the missing Tuple import to the canonicalization service so the module can be imported

## Testing
- not run (dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d8f50dd3e88321baadb566dd987ff4