### PR TITLE
Store qualitative method relations and expose in graph

### DIFF
--- a/backend/app/db/migrations/0009_method_relations.sql
+++ b/backend/app/db/migrations/0009_method_relations.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS method_relations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    paper_id UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    method_id UUID NOT NULL REFERENCES methods(id) ON DELETE CASCADE,
+    dataset_id UUID REFERENCES datasets(id) ON DELETE SET NULL,
+    task_id UUID REFERENCES tasks(id) ON DELETE SET NULL,
+    relation_type TEXT NOT NULL,
+    confidence DOUBLE PRECISION,
+    evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_method_relations_paper_id
+    ON method_relations (paper_id);
+
+CREATE INDEX IF NOT EXISTS idx_method_relations_method_id
+    ON method_relations (method_id);
+
+CREATE INDEX IF NOT EXISTS idx_method_relations_dataset_id
+    ON method_relations (dataset_id);
+
+CREATE INDEX IF NOT EXISTS idx_method_relations_task_id
+    ON method_relations (task_id);

--- a/backend/app/models/ontology.py
+++ b/backend/app/models/ontology.py
@@ -108,6 +108,11 @@ class ConceptResolutionType(str, Enum):
     TASK = "task"
 
 
+class MethodRelationType(str, Enum):
+    EVALUATES_ON = "evaluates_on"
+    PROPOSES = "proposes"
+
+
 class ResultBase(BaseModel):
     method_id: Optional[UUID] = None
     dataset_id: Optional[UUID] = None
@@ -172,6 +177,29 @@ class PaperRelationCreate(PaperRelationBase):
 class PaperRelation(PaperRelationBase):
     id: UUID
     src_paper_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class MethodRelationBase(BaseModel):
+    method_id: UUID
+    relation_type: MethodRelationType
+    dataset_id: Optional[UUID] = None
+    task_id: Optional[UUID] = None
+    confidence: Optional[float] = None
+    evidence: EvidencePayload = Field(default_factory=list)
+
+
+class MethodRelationCreate(MethodRelationBase):
+    paper_id: UUID
+
+
+class MethodRelation(MethodRelationBase):
+    id: UUID
+    paper_id: UUID
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/extraction_tier3.py
+++ b/backend/app/services/extraction_tier3.py
@@ -8,8 +8,15 @@ from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 from uuid import UUID
 
-from app.models.ontology import ResultCreate
-from app.services.ontology_store import append_results, ensure_dataset, ensure_method, ensure_metric, ensure_task
+from app.models.ontology import MethodRelationCreate, MethodRelationType, ResultCreate
+from app.services.ontology_store import (
+    append_method_relations,
+    append_results,
+    ensure_dataset,
+    ensure_method,
+    ensure_metric,
+    ensure_task,
+)
 TIER_NAME = "tier3_verifier"
 _BASE_CONFIDENCE_FALLBACK = 0.55
 _JSON_VALID_BONUS = 0.05
@@ -17,6 +24,9 @@ _COREF_BONUS = 0.04
 _TABLE_MATCH_BONUS = 0.1
 _DUPLICATE_BONUS_STEP = 0.03
 _DUPLICATE_BONUS_CAP = 0.09
+_QUALITATIVE_RELATION_CONFIDENCE = 0.65
+_DATASET_RELATION_GUESSES = {"EVALUATED_ON", "USES", "TRAINS_ON", "TESTED_ON"}
+_TASK_RELATION_GUESSES = {"PROPOSES", "ADDRESSES", "SOLVES", "TARGETS"}
 
 _COREF_HEAD_PATTERN = re.compile(
     r"^(?:this|that|these|those|our|the|its|their|it|they)\b",
@@ -135,7 +145,7 @@ async def run_tier3_verifier(
         wrapper.data for wrapper in sorted(wrapped, key=lambda item: item.original_index)
     ]
 
-    persisted_count = await _persist_structured_results(paper_id, wrapped)
+    persisted_counts = await _persist_structured_results(paper_id, wrapped)
 
     metadata = summary.setdefault("metadata", {})
     tier3_meta = {
@@ -145,8 +155,10 @@ async def run_tier3_verifier(
         "table_matches": sum(1 for wrapper in wrapped if wrapper.table_match),
         "coref_resolved": sum(1 for wrapper in wrapped if wrapper.coref_resolved),
     }
-    if persisted_count:
-        tier3_meta["persisted_results"] = persisted_count
+    if persisted_counts.get("results"):
+        tier3_meta["persisted_results"] = persisted_counts["results"]
+    if persisted_counts.get("relations"):
+        tier3_meta["persisted_relations"] = persisted_counts["relations"]
     metadata["tier3"] = tier3_meta
     return summary
 
@@ -475,31 +487,40 @@ def _update_confidences(candidates: Sequence[CandidateWrapper]) -> None:
 async def _persist_structured_results(
     paper_id: UUID,
     candidates: Sequence[CandidateWrapper],
-) -> int:
+) -> dict[str, int]:
     results: list[ResultCreate] = []
-    local_keys: set[tuple[Any, ...]] = set()
+    result_keys: set[tuple[Any, ...]] = set()
+    relations: list[MethodRelationCreate] = []
+    relation_keys: set[tuple[Any, ...]] = set()
 
     for wrapper in candidates:
-        outcome = await _candidate_to_result(paper_id, wrapper)
-        if outcome is None:
-            continue
-        result, key = outcome
-        if key in local_keys:
-            continue
-        local_keys.add(key)
-        results.append(result)
+        result_outcome, relation_outcomes = await _candidate_to_result(paper_id, wrapper)
+        if result_outcome:
+            result, key = result_outcome
+            if key not in result_keys:
+                result_keys.add(key)
+                results.append(result)
+        for relation, key in relation_outcomes:
+            if key in relation_keys:
+                continue
+            relation_keys.add(key)
+            relations.append(relation)
 
-    if not results:
-        return 0
+    inserted_results = await append_results(paper_id, results) if results else []
+    inserted_relations = (
+        await append_method_relations(paper_id, relations) if relations else []
+    )
 
-    inserted = await append_results(paper_id, results)
-    return len(inserted)
+    return {"results": len(inserted_results), "relations": len(inserted_relations)}
 
 
 async def _candidate_to_result(
     paper_id: UUID,
     wrapper: CandidateWrapper,
-) -> Optional[tuple[ResultCreate, tuple[Any, ...]]]:
+) -> tuple[
+    Optional[tuple[ResultCreate, tuple[Any, ...]]],
+    list[tuple[MethodRelationCreate, tuple[Any, ...]]],
+]:
     data = wrapper.data
     subject = (data.get("subject") or "").strip()
     obj = (data.get("object") or "").strip()
@@ -546,10 +567,10 @@ async def _candidate_to_result(
         method_name = _clean_entity_name(obj)
 
     if not method_name:
-        return None
+        return None, []
 
     if not any([dataset_name, metric_name, task_name, measurement]):
-        return None
+        return None, []
 
     method_model = await ensure_method(method_name)
     dataset_model = await ensure_dataset(dataset_name) if dataset_name else None
@@ -586,30 +607,81 @@ async def _candidate_to_result(
     except (TypeError, ValueError):
         confidence_value = None
 
-    result = ResultCreate(
-        paper_id=paper_id,
-        method_id=method_model.id,
-        dataset_id=dataset_model.id if dataset_model else None,
-        metric_id=metric_model.id if metric_model else None,
-        task_id=task_model.id if task_model else None,
-        split=measurement.split if measurement else None,
-        value_numeric=value_numeric,
-        value_text=value_text,
-        is_sota=False,
-        confidence=confidence_value,
-        evidence=evidence,
-    )
+    result_outcome: Optional[tuple[ResultCreate, tuple[Any, ...]]] = None
+    relation_outcomes: list[tuple[MethodRelationCreate, tuple[Any, ...]]] = []
 
-    key = (
-        result.method_id,
-        result.dataset_id,
-        result.metric_id,
-        result.task_id,
-        result.split,
-        (result.value_text or "").strip(),
-        str(result.value_numeric) if result.value_numeric is not None else None,
-    )
-    return result, key
+    if measurement:
+        result = ResultCreate(
+            paper_id=paper_id,
+            method_id=method_model.id,
+            dataset_id=dataset_model.id if dataset_model else None,
+            metric_id=metric_model.id if metric_model else None,
+            task_id=task_model.id if task_model else None,
+            split=measurement.split,
+            value_numeric=value_numeric,
+            value_text=value_text,
+            is_sota=False,
+            confidence=confidence_value,
+            evidence=evidence,
+        )
+
+        key = (
+            result.method_id,
+            result.dataset_id,
+            result.metric_id,
+            result.task_id,
+            result.split,
+            (result.value_text or "").strip(),
+            str(result.value_numeric) if result.value_numeric is not None else None,
+        )
+        result_outcome = (result, key)
+    else:
+        if confidence_value is None:
+            confidence_value = 0.0
+        if confidence_value >= _QUALITATIVE_RELATION_CONFIDENCE:
+            if dataset_model and (
+                relation_guess in _DATASET_RELATION_GUESSES
+                or object_type == "dataset"
+            ):
+                relation = MethodRelationCreate(
+                    paper_id=paper_id,
+                    method_id=method_model.id,
+                    dataset_id=dataset_model.id,
+                    task_id=None,
+                    relation_type=MethodRelationType.EVALUATES_ON,
+                    confidence=confidence_value,
+                    evidence=evidence,
+                )
+                key = (
+                    relation.method_id,
+                    relation.dataset_id,
+                    relation.task_id,
+                    relation.relation_type,
+                )
+                relation_outcomes.append((relation, key))
+            if task_model and (
+                relation_guess in _TASK_RELATION_GUESSES
+                or object_type == "task"
+                or subject_type == "task"
+            ):
+                relation = MethodRelationCreate(
+                    paper_id=paper_id,
+                    method_id=method_model.id,
+                    dataset_id=None,
+                    task_id=task_model.id,
+                    relation_type=MethodRelationType.PROPOSES,
+                    confidence=confidence_value,
+                    evidence=evidence,
+                )
+                key = (
+                    relation.method_id,
+                    relation.dataset_id,
+                    relation.task_id,
+                    relation.relation_type,
+                )
+                relation_outcomes.append((relation, key))
+
+    return result_outcome, relation_outcomes
 
 
 def _clean_entity_name(value: Optional[str]) -> Optional[str]:

--- a/backend/app/services/graph.py
+++ b/backend/app/services/graph.py
@@ -92,6 +92,37 @@ _RESULT_SELECT = """
     LEFT JOIN tasks t ON r.task_id = t.id
 """
 
+_METHOD_RELATION_SELECT = """
+    SELECT
+        mr.id AS result_id,
+        mr.paper_id,
+        mr.method_id,
+        mr.dataset_id,
+        NULL::uuid AS metric_id,
+        mr.task_id,
+        mr.confidence,
+        mr.evidence,
+        p.title AS paper_title,
+        m.name AS method_name,
+        m.aliases AS method_aliases,
+        m.description AS method_description,
+        d.name AS dataset_name,
+        d.aliases AS dataset_aliases,
+        d.description AS dataset_description,
+        NULL::text AS metric_name,
+        NULL::jsonb AS metric_aliases,
+        NULL::text AS metric_description,
+        NULL::text AS metric_unit,
+        t.name AS task_name,
+        t.aliases AS task_aliases,
+        t.description AS task_description
+    FROM method_relations mr
+    JOIN papers p ON p.id = mr.paper_id
+    LEFT JOIN methods m ON mr.method_id = m.id
+    LEFT JOIN datasets d ON mr.dataset_id = d.id
+    LEFT JOIN tasks t ON mr.task_id = t.id
+"""
+
 
 class GraphEntityNotFoundError(RuntimeError):
     """Raised when the requested graph node cannot be located."""
@@ -239,6 +270,19 @@ async def _fetch_results(
             list(paper_ids),
         )
     return await conn.fetch(_RESULT_SELECT)
+
+
+async def _fetch_method_relations(
+    conn: Any,
+    *,
+    paper_ids: Optional[Sequence[UUID]] = None,
+) -> Sequence[Mapping[str, Any]]:
+    if paper_ids:
+        return await conn.fetch(
+            f"{_METHOD_RELATION_SELECT} WHERE mr.paper_id = ANY($1::uuid[])",
+            list(paper_ids),
+        )
+    return await conn.fetch(_METHOD_RELATION_SELECT)
 
 
 async def _fetch_concept_fallback_rows(
@@ -1018,7 +1062,9 @@ async def get_graph_overview(
     pool = get_pool()
     async with pool.acquire() as conn:
         records = await _fetch_results(conn)
+        relation_records = await _fetch_method_relations(conn)
         rows = [dict(record) for record in records]
+        rows.extend(dict(record) for record in relation_records)
         node_details: dict[tuple[NodeType, UUID], NodeDetail] = {}
         aggregated_edges = _aggregate_edges(rows, allowed_types, allowed_relations, min_conf, node_details)
     response = _build_graph_response(
@@ -1076,7 +1122,9 @@ async def get_graph_neighborhood(
 
         paper_ids = await _fetch_related_papers(conn, center_detail)
         records = await _fetch_results(conn, paper_ids=paper_ids)
+        relation_records = await _fetch_method_relations(conn, paper_ids=paper_ids)
         rows = [dict(record) for record in records]
+        rows.extend(dict(record) for record in relation_records)
 
     allowed_types.add(center_detail.type)
 


### PR DESCRIPTION
## Summary
- add ontology models and a migration for persisting qualitative method relations per paper
- teach the tier-3 verifier to capture high-confidence method-to-dataset/task relations without numeric measurements and persist them via the ontology store
- surface stored qualitative relations in the graph service before falling back to placeholder concepts and cover the flow with new tests

## Testing
- `pytest backend/tests/test_tier3_verifier.py`
- `pytest backend/tests/test_graph_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd752ab8548321afd20c62899d7d2e