### PR TITLE
Add migration to backfill triple_candidates graph_metadata column

### DIFF
--- a/backend/app/db/migrations/0010_triple_candidates_graph_metadata.sql
+++ b/backend/app/db/migrations/0010_triple_candidates_graph_metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE triple_candidates
+    ADD COLUMN IF NOT EXISTS graph_metadata JSONB NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary
- add a database migration that ensures the triple_candidates table includes the graph_metadata column expected by the backend

## Testing
- not run (database migration only)


------
https://chatgpt.com/codex/tasks/task_e_68dd734cbe3883218f9eca2f4d78bea0