### PR TITLE
Normalize Tier-2 spans before schema validation

### DIFF
--- a/backend/tests/test_extraction_tier2_llm.py
+++ b/backend/tests/test_extraction_tier2_llm.py
@@ -528,3 +528,24 @@ def test_merge_payloads_dedupes_entries() -> None:
         "Another note",
     ]
     assert merged.discarded == ["Row 1", "Row 2", "Row 3"]
+
+
+def test_validate_payload_allows_single_value_spans() -> None:
+    payload = {
+        "triples": [
+            {
+                "subject": "AB",
+                "relation": "improves",
+                "object": "accuracy",
+                "evidence": "AB improves accuracy on the benchmark dataset.",
+                "subject_span": [11],
+                "object_span": [22],
+            }
+        ]
+    }
+
+    validated = extraction_tier2._validate_payload(payload)
+    triple = validated.triples[0]
+
+    assert triple.subject_span == [11, 11]
+    assert triple.object_span == [22, 22]


### PR DESCRIPTION
## Summary
- normalize Tier-2 span fields before schema validation so singleton offsets no longer fail the payload check
- add a regression test covering Tier-2 responses that provide single-value spans

## Testing
- pytest backend/tests/test_extraction_tier2_llm.py::test_validate_payload_allows_single_value_spans *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68dc332f21d083218c099856b7c955fa