### PR TITLE
Restrict graph metadata pairs to relevant relation guesses

### DIFF
--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -416,9 +416,15 @@ def _extract_graph_entities(
     }
 
 
+GRAPH_DATASET_RELATIONS = {"EVALUATED_ON", "USES"}
+GRAPH_METRIC_RELATIONS = {"MEASURES", "REPORTS"}
+GRAPH_TASK_RELATIONS = {"PROPOSES"}
+
+
 def _build_graph_metadata(
     entities: Mapping[str, Optional[str]],
     *,
+    relation_type_guess: Optional[str],
     matches: Sequence[Mapping[str, Any]],
     evidence_text: str,
     section_id: Optional[str],
@@ -474,9 +480,14 @@ def _build_graph_metadata(
             }
         )
 
-    _append_pair("dataset", entities.get("dataset"), "evaluates_on")
-    _append_pair("metric", entities.get("metric"), "reports")
-    _append_pair("task", entities.get("task"), "proposes")
+    normalized_guess = (relation_type_guess or "").strip().upper()
+
+    if normalized_guess in GRAPH_DATASET_RELATIONS:
+        _append_pair("dataset", entities.get("dataset"), "evaluates_on")
+    if normalized_guess in GRAPH_METRIC_RELATIONS:
+        _append_pair("metric", entities.get("metric"), "reports")
+    if normalized_guess in GRAPH_TASK_RELATIONS:
+        _append_pair("task", entities.get("task"), "proposes")
 
     if metadata["pairs"]:
         return metadata
@@ -1163,6 +1174,7 @@ def _build_candidates(
         )
         graph_metadata = _build_graph_metadata(
             graph_entities,
+            relation_type_guess=triple.relation_type_guess,
             matches=matches,
             evidence_text=evidence_text,
             section_id=candidate_section_id,


### PR DESCRIPTION
## Summary
- gate Tier-2 graph metadata emission on relation_type_guess so only evaluation, measurement, and proposal relations create dataset/metric/task pairs
- pass relation_type_guess through candidate construction and reuse gating during Tier-3 measurement enrichment with fallbacks for parsed datasets, metrics, and tasks
- add Tier-2 test coverage ensuring non-evaluation dataset triples no longer include graph metadata

## Testing
- pytest backend/tests/test_extraction_tier2_llm.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68de4ff44da8832185bf50d5b28b3efe