### PR TITLE
Refine Tier-2 section chunking

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,6 +59,12 @@ class Settings(BaseSettings):
     tier2_llm_top_p: float = Field(default=1.0)
     tier2_llm_timeout_seconds: float = Field(default=120.0)
     tier2_llm_max_sections: int = Field(default=24)
+    # Maximum characters per Tier-2 section chunk after formatting "[idx] sentence" lines.
+    tier2_llm_section_chunk_chars: int = Field(default=3500)
+    # Number of sentences to overlap between successive section chunks.
+    tier2_llm_section_chunk_overlap_sentences: int = Field(default=1)
+    # Hard limit on how many chunks can be produced from a single section.
+    tier2_llm_max_chunks_per_section: int = Field(default=3)
     tier2_llm_max_section_chars: int = Field(default=3500)
     tier2_llm_force_json: bool = Field(default=True)
     tier2_llm_max_output_tokens: int = Field(default=8129)

--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -139,6 +139,7 @@ class SectionContext:
     page_number: int | None
     sentences: list[tuple[int, str]]
     captions: list[str]
+    chunk_id: str | None = None
 
     def formatted_text(self) -> str:
         lines: list[str] = []
@@ -617,12 +618,19 @@ def _is_low_info_text(value: str) -> bool:
 def _find_context_by_id(
     contexts: Sequence[SectionContext],
     section_id: Optional[str],
+    *,
+    chunk_id: Optional[str] = None,
 ) -> Optional[SectionContext]:
-    if not section_id:
-        return None
-    for context in contexts:
-        if context.section_id == section_id:
-            return context
+    if section_id:
+        for context in contexts:
+            if context.section_id == section_id and (
+                chunk_id is None or context.chunk_id == chunk_id
+            ):
+                return context
+    if chunk_id:
+        for context in contexts:
+            if context.chunk_id == chunk_id:
+                return context
     return None
 
 
@@ -651,7 +659,11 @@ def _find_antecedent(
 ) -> Optional[str]:
     for match in matches:
         section_id = match.get("section_id")
-        context = _find_context_by_id(contexts, section_id)
+        context = _find_context_by_id(
+            contexts,
+            section_id,
+            chunk_id=match.get("chunk_id"),
+        )
         if context is None:
             continue
         sentence_index = match.get("sentence_index")
@@ -983,8 +995,17 @@ async def _request_llm_payload(
 
 
 def _prepare_section_contexts(sections: Sequence[dict[str, Any]]) -> list[SectionContext]:
-    limit = max(1, settings.tier2_llm_max_sections or 1)
-    max_chars = max(400, settings.tier2_llm_max_section_chars or 2000)
+    chunk_limit = max(1, settings.tier2_llm_max_sections or 1)
+    raw_budget = (
+        settings.tier2_llm_section_chunk_chars
+        or settings.tier2_llm_max_section_chars
+        or 2000
+    )
+    chunk_budget = max(400, raw_budget)
+    chunk_overlap = max(0, settings.tier2_llm_section_chunk_overlap_sentences or 0)
+    max_chunks_per_section = max(
+        1, settings.tier2_llm_max_chunks_per_section or 1
+    )
 
     def _section_sort_key(section: dict[str, Any]) -> tuple[int, int]:
         page = section.get("page_number")
@@ -997,7 +1018,7 @@ def _prepare_section_contexts(sections: Sequence[dict[str, Any]]) -> list[Sectio
     contexts: list[SectionContext] = []
 
     for section in ordered:
-        if len(contexts) >= limit:
+        if len(contexts) >= chunk_limit:
             break
         section_id = str(section.get("section_id") or "").strip()
         if not section_id:
@@ -1009,7 +1030,6 @@ def _prepare_section_contexts(sections: Sequence[dict[str, Any]]) -> list[Sectio
         if not isinstance(sentences_payload, list):
             continue
         sentences: list[tuple[int, str]] = []
-        running_chars = 0
         for sentence_index, sentence in enumerate(sentences_payload):
             if not isinstance(sentence, dict):
                 continue
@@ -1019,12 +1039,7 @@ def _prepare_section_contexts(sections: Sequence[dict[str, Any]]) -> list[Sectio
             text = raw_text.strip()
             if not text:
                 continue
-            formatted = f"[{sentence_index}] {text}"
-            addition = len(formatted) + 1
-            if running_chars + addition > max_chars and sentences:
-                break
             sentences.append((sentence_index, text))
-            running_chars += addition
         if not sentences:
             continue
         captions_raw = section.get("captions") or []
@@ -1033,16 +1048,53 @@ def _prepare_section_contexts(sections: Sequence[dict[str, Any]]) -> list[Sectio
             for caption in captions_raw
             if isinstance(caption, dict) and caption.get("text")
         ]
-        contexts.append(
-            SectionContext(
-                section_id=section_id,
-                section_hash=section_hash,
-                title=title,
-                page_number=page_number,
-                sentences=sentences,
-                captions=captions,
+        start_index = 0
+        chunk_index = 0
+        total_sentences = len(sentences)
+        while (
+            start_index < total_sentences
+            and chunk_index < max_chunks_per_section
+            and len(contexts) < chunk_limit
+        ):
+            idx = start_index
+            chunk_sentences: list[tuple[int, str]] = []
+            running_chars = 0
+            while idx < total_sentences:
+                sentence_entry = sentences[idx]
+                formatted = f"[{sentence_entry[0]}] {sentence_entry[1]}"
+                addition = len(formatted) + 1
+                if chunk_sentences and running_chars + addition > chunk_budget:
+                    break
+                chunk_sentences.append(sentence_entry)
+                running_chars += addition
+                idx += 1
+                if running_chars >= chunk_budget:
+                    break
+
+            if not chunk_sentences:
+                break
+
+            chunk_index += 1
+            chunk_id = f"{section_id}#chunk-{chunk_index:02d}"
+            contexts.append(
+                SectionContext(
+                    section_id=section_id,
+                    section_hash=section_hash,
+                    title=title,
+                    page_number=page_number,
+                    sentences=chunk_sentences,
+                    captions=captions,
+                    chunk_id=chunk_id,
+                )
             )
-        )
+
+            if len(contexts) >= chunk_limit or idx >= total_sentences:
+                break
+
+            next_start = max(idx - chunk_overlap, 0)
+            if next_start <= start_index:
+                next_start = idx
+            start_index = next_start
 
     return contexts
 
@@ -1082,6 +1134,8 @@ def _build_messages(contexts: Sequence[SectionContext], *, mode: str = "primary"
             header_parts.append(f"page={context.page_number}")
         if context.section_hash:
             header_parts.append(f"hash={context.section_hash}")
+        if context.chunk_id:
+            header_parts.append(f"chunk={context.chunk_id}")
         content_lines.append(" | ".join(header_parts))
         content_lines.append("---")
         content_lines.append(context.formatted_text())
@@ -1138,6 +1192,7 @@ def _build_candidates(
         if not matches:
             stats.unmatched_evidence += 1
         candidate_section_id = triple.section_id or (matches[0]["section_id"] if matches else None)
+        candidate_chunk_id = triple.chunk_id or (matches[0].get("chunk_id") if matches else None)
         primary_match_length = (
             matches[0]["end"] - matches[0]["start"] if matches else None
         )
@@ -1206,7 +1261,7 @@ def _build_candidates(
             object_text,
             evidence_text,
             candidate_section_id,
-            triple.chunk_id,
+            candidate_chunk_id,
         )
         if dedupe_key in seen_keys:
             stats.deduplicated_triples += 1
@@ -1250,8 +1305,8 @@ def _build_candidates(
 
         if candidate_section_id:
             candidate["section_id"] = candidate_section_id
-        if triple.chunk_id:
-            candidate["chunk_id"] = triple.chunk_id
+        if candidate_chunk_id:
+            candidate["chunk_id"] = candidate_chunk_id
         if pass_label:
             candidate["pass"] = pass_label
 
@@ -1334,6 +1389,7 @@ def _match_evidence(
             matches.append(
                 {
                     "section_id": context.section_id,
+                    "chunk_id": context.chunk_id,
                     "sentence_index": sentence_index,
                     "start": start,
                     "end": end,

--- a/backend/tests/test_extraction_tier2_llm.py
+++ b/backend/tests/test_extraction_tier2_llm.py
@@ -30,6 +30,36 @@ def _build_section(section_id: str, title: str, sentences: list[str]) -> dict[st
     }
 
 
+def test_prepare_section_contexts_splits_long_sections(monkeypatch: pytest.MonkeyPatch) -> None:
+    section = _build_section(
+        "sec-long",
+        "Analysis",
+        [
+            "Sentence 0 provides background on the approach and includes multiple clauses to be long.",
+            "Sentence 1 continues the discussion with more detail and elaboration for testing purposes.",
+            "Sentence 2 introduces additional results that ensure chunking will require a third chunk eventually.",
+            "Sentence 3 adds further elaboration so that there is enough material for more chunks in the dataset.",
+            "Sentence 4 concludes the section but is still lengthy to challenge the chunking routine effectively.",
+        ],
+    )
+    section["captions"] = [{"text": "Figure 1. Chunk demo."}]
+
+    monkeypatch.setattr(settings, "tier2_llm_section_chunk_chars", 280)
+    monkeypatch.setattr(settings, "tier2_llm_section_chunk_overlap_sentences", 1)
+    monkeypatch.setattr(settings, "tier2_llm_max_chunks_per_section", 10)
+    monkeypatch.setattr(settings, "tier2_llm_max_sections", 2)
+
+    contexts = extraction_tier2._prepare_section_contexts([section])
+
+    assert len(contexts) == 2
+    assert contexts[0].chunk_id and contexts[1].chunk_id
+    assert contexts[0].chunk_id.endswith("01")
+    assert contexts[1].chunk_id.endswith("02")
+    assert contexts[0].captions == ["Figure 1. Chunk demo."]
+    assert contexts[1].captions == contexts[0].captions
+    assert contexts[0].sentences[-1][0] == contexts[1].sentences[0][0]
+
+
 @pytest.mark.anyio
 async def test_run_tier2_structurer_parses_llm_response(monkeypatch: pytest.MonkeyPatch) -> None:
     paper_id = uuid4()
@@ -130,6 +160,92 @@ async def test_run_tier2_structurer_parses_llm_response(monkeypatch: pytest.Monk
     assert stored_candidate.subject == "AlphaNet"
     assert stored_candidate.section_id == "sec-2"
     assert stored_candidate.object_span == [18, 48]
+
+
+@pytest.mark.anyio
+async def test_run_tier2_structurer_populates_chunk_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    paper_id = uuid4()
+    sentences = [
+        "The introduction sentence elaborates on the motivation for the study and is intentionally long.",
+        "The methods sentence contains specific phrasing that will be used as evidence for chunk two.",
+        "The results sentence highlights the improvements achieved by the proposed system in extensive detail.",
+    ]
+    base_summary = {
+        "paper_id": str(paper_id),
+        "tiers": [1],
+        "sections": [
+            _build_section(
+                "sec-chunk",
+                "Methods",
+                sentences,
+            ),
+        ],
+        "tables": [],
+    }
+    base_summary["sections"][0]["captions"] = [{"text": "Table 1 summarizes results."}]
+
+    monkeypatch.setattr(settings, "tier2_llm_section_chunk_chars", 170)
+    monkeypatch.setattr(settings, "tier2_llm_section_chunk_overlap_sentences", 1)
+    monkeypatch.setattr(settings, "tier2_llm_max_chunks_per_section", 5)
+    monkeypatch.setattr(settings, "tier2_llm_max_sections", 5)
+
+    contexts = extraction_tier2._prepare_section_contexts(base_summary["sections"])
+    assert len(contexts) >= 2
+    target_chunk = contexts[1]
+    evidence_sentence = target_chunk.sentences[-1][1]
+
+    fake_payload = {
+        "triples": [
+            {
+                "subject": "ChunkNet",
+                "relation": "uses",
+                "object": "special phrasing",
+                "evidence": evidence_sentence,
+                "subject_span": [0, 8],
+                "object_span": [25, 40],
+                "subject_type_guess": "Method",
+                "relation_type_guess": "USES",
+                "object_type_guess": "OtherScientificTerm",
+                "triple_conf": 0.7,
+                "schema_match_score": 0.9,
+                "section_id": "sec-chunk",
+            }
+        ],
+        "warnings": [],
+        "discarded": [],
+    }
+
+    payload_iter = iter([
+        fake_payload,
+        {"triples": [], "warnings": [], "discarded": []},
+    ])
+
+    async def fake_invoke_llm(_: list[dict[str, str]]) -> str:
+        payload = next(payload_iter, {"triples": [], "warnings": [], "discarded": []})
+        return json.dumps(payload)
+
+    async def fake_replace(_: UUID, __: list) -> None:
+        return None
+
+    monkeypatch.setattr(extraction_tier2, "_invoke_llm", fake_invoke_llm)
+    monkeypatch.setattr(extraction_tier2, "replace_triple_candidates", fake_replace)
+
+    monkeypatch.setattr(settings, "tier2_llm_model", "gpt-test")
+    monkeypatch.setattr(settings, "tier2_llm_base_url", "https://example.com")
+    monkeypatch.setattr(settings, "tier2_llm_completion_path", "/chat/completions")
+    monkeypatch.setattr(settings, "tier2_llm_force_json", True)
+    monkeypatch.setattr(settings, "openai_api_key", None)
+    monkeypatch.setattr(settings, "openai_organization", None)
+
+    summary = await extraction_tier2.run_tier2_structurer(paper_id, base_summary=base_summary)
+
+    candidates = summary["triple_candidates"]
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["section_id"] == "sec-chunk"
+    assert candidate["chunk_id"] == target_chunk.chunk_id
+    evidence_spans = candidate["evidence_spans"]
+    assert evidence_spans and evidence_spans[0]["chunk_id"] == target_chunk.chunk_id
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add configuration knobs for Tier-2 LLM section chunk sizing, overlap, and per-section limits
- refactor section context preparation to emit chunk-aware contexts and propagate chunk identifiers through matching and candidate building
- extend Tier-2 unit tests to cover multi-chunk sections and ensure chunk identifiers appear in results

## Testing
- pytest backend/tests/test_extraction_tier2_llm.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68de53eb0b908321a6694b4faab47ccf