### PR TITLE
Make Tier-2 triple limit configurable

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,6 +62,10 @@ class Settings(BaseSettings):
     tier2_llm_max_section_chars: int = Field(default=3500)
     tier2_llm_force_json: bool = Field(default=True)
     tier2_llm_max_output_tokens: int = Field(default=8129)
+    tier2_llm_max_triples: int = Field(
+        default=45,
+        description="Maximum number of triples expected from the Tier-2 LLM response.",
+    )
 
     class Config:
         env_file = ".env"

--- a/backend/app/schemas/tier2.py
+++ b/backend/app/schemas/tier2.py
@@ -4,6 +4,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.core.config import settings
+
 TYPE_GUESS_VALUES: tuple[str, ...] = (
     "Method",
     "Task",
@@ -95,6 +97,8 @@ class TripleExtractionResponse(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    triples: list[TriplePayload] = Field(default_factory=list, max_length=15)
+    triples: list[TriplePayload] = Field(
+        default_factory=list, max_length=settings.tier2_llm_max_triples
+    )
     discarded: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)

--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -64,12 +64,11 @@ METRIC_SYNONYM_MAP: dict[str, dict[str, str]] = {
 }
 
 
-TRIPLE_JSON_SCHEMA: dict[str, Any] = {
+TRIPLE_JSON_SCHEMA_TEMPLATE: dict[str, Any] = {
     "type": "object",
     "properties": {
         "triples": {
             "type": "array",
-            "maxItems": 15,
             "items": {
                 "type": "object",
                 "required": [
@@ -129,6 +128,21 @@ TRIPLE_JSON_SCHEMA: dict[str, Any] = {
     "required": ["triples"],
     "additionalProperties": False,
 }
+
+
+def _build_triple_json_schema(max_triples: int) -> dict[str, Any]:
+    schema = copy.deepcopy(TRIPLE_JSON_SCHEMA_TEMPLATE)
+    schema["properties"]["triples"]["maxItems"] = max_triples
+    return schema
+
+
+def get_triple_json_schema() -> dict[str, Any]:
+    """Return the triple JSON schema using the current settings."""
+
+    return _build_triple_json_schema(settings.tier2_llm_max_triples)
+
+
+TRIPLE_JSON_SCHEMA: dict[str, Any] = get_triple_json_schema()
 
 
 @dataclass
@@ -1461,7 +1475,7 @@ async def _invoke_llm(messages: Sequence[dict[str, str]]) -> str:
             "type": "json_schema",
             "json_schema": {
                 "name": "triple_extraction",
-                "schema": TRIPLE_JSON_SCHEMA,
+                "schema": get_triple_json_schema(),
             },
         }
     else:

--- a/backend/tests/test_extraction_tier2_llm.py
+++ b/backend/tests/test_extraction_tier2_llm.py
@@ -15,6 +15,14 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
+def test_get_triple_json_schema_respects_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "tier2_llm_max_triples", 7)
+
+    schema = extraction_tier2.get_triple_json_schema()
+
+    assert schema["properties"]["triples"]["maxItems"] == 7
+
+
 def _build_section(section_id: str, title: str, sentences: list[str]) -> dict[str, object]:
     return {
         "section_id": section_id,


### PR DESCRIPTION
## Summary
- add a configurable `tier2_llm_max_triples` setting for the Tier-2 LLM service
- use the configured limit when constructing the triple extraction JSON schema and payload models
- cover the new behaviour with a regression test that patches the runtime limit

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_extraction_tier2_llm.py -k get_triple_json_schema_respects_settings` *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de54408bc88321bf5b7b4efd224b49