### PR TITLE
Emphasize tier2 extraction prompt recall and make it configurable

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,6 +62,14 @@ class Settings(BaseSettings):
     tier2_llm_max_section_chars: int = Field(default=3500)
     tier2_llm_force_json: bool = Field(default=True)
     tier2_llm_max_output_tokens: int = Field(default=8129)
+    tier2_llm_system_prompt: str = Field(
+        default=(
+            "You extract scientific facts as (subject, relation, object) with evidence. "
+            "Use precise noun phrases and exact character spans. Prioritize capturing every "
+            "statement the passage explicitly supports with evidence; only skip when support is "
+            "missing or spans cannot be resolved."
+        )
+    )
 
     class Config:
         env_file = ".env"
@@ -69,3 +77,4 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+

--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -27,10 +27,7 @@ from app.services.triple_candidates import replace_triple_candidates
 logger = logging.getLogger(__name__)
 
 TIER_NAME = "tier2_llm_openie"
-SYSTEM_PROMPT = (
-    "You extract scientific facts as (subject, relation, object) with evidence. "
-    "Use precise noun phrases. Be conservative: if unsure, omit."
-)
+SYSTEM_PROMPT = settings.tier2_llm_system_prompt
 DEFAULT_TRIPLE_CONFIDENCE = 0.55
 DEFAULT_SCHEMA_SCORE = 1.0
 MAX_LLM_ATTEMPTS = 2

--- a/backend/tests/test_extraction_tier2_llm.py
+++ b/backend/tests/test_extraction_tier2_llm.py
@@ -96,6 +96,8 @@ async def test_run_tier2_structurer_parses_llm_response(monkeypatch: pytest.Monk
     monkeypatch.setattr(extraction_tier2, "_invoke_llm", fake_invoke_llm)
     monkeypatch.setattr(extraction_tier2, "replace_triple_candidates", fake_replace)
 
+    custom_prompt = "Extract every supported claim with precise spans."
+    monkeypatch.setattr(settings, "tier2_llm_system_prompt", custom_prompt)
     monkeypatch.setattr(settings, "tier2_llm_model", "gpt-test")
     monkeypatch.setattr(settings, "tier2_llm_base_url", "https://example.com")
     monkeypatch.setattr(settings, "tier2_llm_completion_path", "/chat/completions")
@@ -120,6 +122,7 @@ async def test_run_tier2_structurer_parses_llm_response(monkeypatch: pytest.Monk
     assert guardrails["unmatched_evidence"] == 0
     assert guardrails["metrics_inferred"] == 0
     assert len(captured_messages) == 2
+    assert captured_messages[0][0]["content"] == custom_prompt
     comparison_prompt = captured_messages[1][1]["content"]
     assert "comparison" in comparison_prompt.lower()
 

--- a/backend/tests/test_settings_loading.py
+++ b/backend/tests/test_settings_loading.py
@@ -6,6 +6,7 @@ import importlib
 def test_settings_reads_environment(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("TIER2_LLM_MODEL", "gpt-test")
+    monkeypatch.setenv("TIER2_LLM_SYSTEM_PROMPT", "Env configured prompt")
 
     config_module = importlib.import_module("backend.app.core.config")
     Settings = config_module.Settings
@@ -14,3 +15,4 @@ def test_settings_reads_environment(monkeypatch):
 
     assert settings.openai_api_key == "test-key"
     assert settings.tier2_llm_model == "gpt-test"
+    assert settings.tier2_llm_system_prompt == "Env configured prompt"


### PR DESCRIPTION
## Summary
- update the tier-2 system prompt to prioritize capturing every evidence-backed claim while retaining precise spans
- expose the prompt text through settings so operators can tune it without code changes
- adjust tier-2 unit tests to cover the configurable prompt and environment overrides

## Testing
- python -m pytest backend/tests/test_extraction_tier2_llm.py backend/tests/test_settings_loading.py *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68de5446d5288321ba22b7913a6b7381