### PR TITLE
Add configurable Tier-2 triple cap setting

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
     tier2_llm_top_p: float = Field(default=1.0)
     tier2_llm_timeout_seconds: float = Field(default=120.0)
     tier2_llm_max_sections: int = Field(default=24)
+    tier2_llm_max_triples: int = Field(default=30)
     # Maximum characters per Tier-2 section chunk after formatting "[idx] sentence" lines.
     tier2_llm_section_chunk_chars: int = Field(default=3500)
     # Number of sentences to overlap between successive section chunks.


### PR DESCRIPTION
## Summary
- add the missing `tier2_llm_max_triples` setting to the backend configuration
- unblock the tier-2 schema and response models that reference the configurable triple cap

## Testing
- pytest backend/tests/test_extraction_tier2_llm.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68de2a0257ac83218830a2cab89c7c95