### PR TITLE
Tighten tier-2 chunking and alias updates

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
     tier2_llm_top_p: float = Field(default=1.0)
     tier2_llm_timeout_seconds: float = Field(default=120.0)
     tier2_llm_max_sections: int = Field(default=24)
+    tier2_llm_max_triples: int = Field(default=30)
     # Maximum characters per Tier-2 section chunk after formatting "[idx] sentence" lines.
     tier2_llm_section_chunk_chars: int = Field(default=3500)
     # Number of sentences to overlap between successive section chunks.

--- a/backend/app/services/canonicalization.py
+++ b/backend/app/services/canonicalization.py
@@ -9,6 +9,11 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, cast
 import re
 from uuid import UUID
 
+try:  # pragma: no cover - optional dependency in tests
+    from asyncpg.pgproto import pgproto  # type: ignore
+except Exception:  # pragma: no cover - asyncpg may be absent in tests
+    pgproto = None  # type: ignore[assignment]
+
 from app.core.config import settings
 from app.db.pool import get_pool
 from app.models.ontology import (
@@ -976,20 +981,16 @@ async def _update_aliases(
     config: _TypeConfig,
     computation: _CanonicalizationComputation,
 ) -> None:
-    updates = []
+    updates: list[tuple[UUID, Any]] = []
     for record_id in computation.id_to_canonical.keys():
         aliases_list = computation.aliases_by_record.get(record_id, [])
-        print(f"[DEBUG] Processing aliases for record {record_id}: {aliases_list}")
-        print(f"[DEBUG] Type of aliases_list: {type(aliases_list)}")
-        if aliases_list:
-            print(f"[DEBUG] Type of first alias: {type(aliases_list[0])}")
-        try:
-            json_str = json.dumps(aliases_list)
-            print(f"[DEBUG] JSON conversion successful: {json_str[:100]}...")
-            updates.append((record_id, json_str))
-        except Exception as exc:
-            print(f"[DEBUG] JSON conversion failed for {aliases_list}: {exc}")
-            raise
+        normalized_aliases = [alias for alias in aliases_list if isinstance(alias, str) and alias]
+        payload: Any
+        if pgproto is not None:
+            payload = pgproto.Jsonb(normalized_aliases)
+        else:
+            payload = normalized_aliases
+        updates.append((record_id, payload))
     if not updates:
         return
     try:

--- a/backend/app/services/extraction_tier3.py
+++ b/backend/app/services/extraction_tier3.py
@@ -573,7 +573,9 @@ def _update_confidences(candidates: Sequence[CandidateWrapper]) -> None:
         score = max(0.0, min(1.0, score))
 
         components: dict[str, float] = {"tier2_base": round(score, 4)}
-        score = _apply_component(score, components, "json_valid", _JSON_VALID_BONUS)
+
+        if wrapper.measurement is not None:
+            score = _apply_component(score, components, "json_valid", _JSON_VALID_BONUS)
 
         if wrapper.coref_resolved:
             score = _apply_component(score, components, "coref_resolution", _COREF_BONUS)


### PR DESCRIPTION
## Summary
- ensure the tier-2 system prompt reflects runtime settings and lower the minimum chunk budget so section chunking can split long inputs as expected
- clean up canonicalization alias persistence to send structured lists (or Jsonb) instead of raw strings
- only award Tier-3 JSON validity bonuses when a numeric measurement is present to keep qualitative confidences unchanged

## Testing
- pytest backend/tests/test_extraction_tier2_llm.py backend/tests/test_canonicalization_service.py backend/tests/test_graph_service.py backend/tests/test_tier3_verifier.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68de2a0257ac83218830a2cab89c7c95