### PR TITLE
Add graph metadata path setting

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -271,6 +271,9 @@ class Settings(BaseSettings):
     # Canonicalization
     canonicalization_mapping_version: int = Field(default=1)
 
+    # Graph
+    graph_metadata_path: Optional[str] = Field(default=None)
+
     # Tier-2 LLM
     openai_api_key: Optional[str] = Field(default=None)
     openai_organization: Optional[str] = Field(default=None)

--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -614,9 +614,13 @@ def _build_graph_metadata(
     if relation is None:
         return {}
 
-    if not _graph_value_valid_for_type(subject_entry.get("normalized"), str(subject_entry.get("type")))):
+    if not _graph_value_valid_for_type(
+        subject_entry.get("normalized"), str(subject_entry.get("type"))
+    ):
         return {}
-    if not _graph_value_valid_for_type(object_entry.get("normalized"), str(object_entry.get("type")))):
+    if not _graph_value_valid_for_type(
+        object_entry.get("normalized"), str(object_entry.get("type"))
+    ):
         return {}
 
     sentence_indices = _collect_sentence_indices(matches)


### PR DESCRIPTION
## Summary
- add a configurable graph metadata path setting to the backend configuration so the graph service can read metadata without errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9dbc55748321ac9c34fcfaee9bd4