### PR TITLE
Handle missing graph metadata setting

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -271,6 +271,9 @@ class Settings(BaseSettings):
     # Canonicalization
     canonicalization_mapping_version: int = Field(default=1)
 
+    # Graph
+    graph_metadata_path: Optional[str] = Field(default=None)
+
     # Tier-2 LLM
     openai_api_key: Optional[str] = Field(default=None)
     openai_organization: Optional[str] = Field(default=None)

--- a/backend/app/services/extraction_tier2.py
+++ b/backend/app/services/extraction_tier2.py
@@ -614,9 +614,13 @@ def _build_graph_metadata(
     if relation is None:
         return {}
 
-    if not _graph_value_valid_for_type(subject_entry.get("normalized"), str(subject_entry.get("type")))):
+    if not _graph_value_valid_for_type(
+        subject_entry.get("normalized"), str(subject_entry.get("type"))
+    ):
         return {}
-    if not _graph_value_valid_for_type(object_entry.get("normalized"), str(object_entry.get("type")))):
+    if not _graph_value_valid_for_type(
+        object_entry.get("normalized"), str(object_entry.get("type"))
+    ):
         return {}
 
     sentence_indices = _collect_sentence_indices(matches)

--- a/backend/app/services/graph_metadata.py
+++ b/backend/app/services/graph_metadata.py
@@ -114,7 +114,7 @@ def _load_metadata_from_path(path: Path) -> GraphOntologyMetadata | None:
 
 
 def _resolve_metadata_path() -> Path | None:
-    raw_path = settings.graph_metadata_path
+    raw_path = getattr(settings, "graph_metadata_path", None)
     if not raw_path:
         return None
     candidate = Path(raw_path)


### PR DESCRIPTION
## Summary
- add a configurable graph metadata path setting to the backend configuration so the graph service can read metadata without errors
- fall back to default graph metadata when the configuration does not expose a graph metadata path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9dbc55748321ac9c34fcfaee9bd4