### PR TITLE
Fix method relation split column reference

### DIFF
--- a/backend/app/services/graph.py
+++ b/backend/app/services/graph.py
@@ -172,7 +172,7 @@ _METHOD_RELATION_SELECT = """
         NULL::text AS value_text,
         NULL::boolean AS is_sota,
         mr.confidence,
-        mr.split,
+        NULL::text AS split,
         NULL::numeric AS value_numeric,
         NULL::text AS value_text,
         NULL::boolean AS is_sota,


### PR DESCRIPTION
## Summary
- avoid selecting the nonexistent `mr.split` column when loading method relation rows
- continue providing a null split value so downstream aggregation receives a consistent shape

## Testing
- pytest backend/tests/test_graph_service.py::test_get_graph_overview_uses_method_relations -q *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68dea8e64e688321a0c846826beb7668