### PR TITLE
Move ontology metadata to JSONB and add provenance support

### DIFF
--- a/backend/app/db/migrations/0012_metadata_and_provenance.sql
+++ b/backend/app/db/migrations/0012_metadata_and_provenance.sql
@@ -1,0 +1,31 @@
+-- Ensure ontology and concept tables have flexible metadata storage
+ALTER TABLE methods
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE datasets
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE metrics
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE concepts
+    ADD COLUMN IF NOT EXISTS aliases JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Index metadata payloads for fast filtering
+CREATE INDEX IF NOT EXISTS idx_methods_metadata ON methods USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_datasets_metadata ON datasets USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_metrics_metadata ON metrics USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_tasks_metadata ON tasks USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_concepts_metadata ON concepts USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_concepts_aliases ON concepts USING GIN (aliases);
+
+-- Add provenance to stored evidence and triples
+ALTER TABLE triple_candidates
+    ADD COLUMN IF NOT EXISTS provenance JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE evidence
+    ADD COLUMN IF NOT EXISTS provenance JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Store claim categories as free-form text
+ALTER TABLE claims
+    ALTER COLUMN category TYPE TEXT USING category::text;
+

--- a/backend/app/models/concept.py
+++ b/backend/app/models/concept.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 
-from typing import Optional
 class ConceptBase(BaseModel):
     name: str = Field(..., min_length=1)
     type: Optional[str] = Field(default=None, max_length=128)
     description: Optional[str] = None
+    aliases: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class ConceptCreate(ConceptBase):

--- a/backend/app/models/evidence.py
+++ b/backend/app/models/evidence.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import json
 from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field
 
 
-from typing import Optional
 class EvidenceBase(BaseModel):
     snippet: str = Field(..., min_length=1)
     section_id: Optional[UUID] = None
@@ -18,17 +16,11 @@ class EvidenceBase(BaseModel):
     embedding_model: Optional[str] = Field(default=None, max_length=255)
     score: Optional[float] = None
     metadata: Optional[dict[str, Any]] = None
+    provenance: Optional[dict[str, Any]] = None
 
 
 class EvidenceCreate(EvidenceBase):
     paper_id: UUID
-
-    # This serializer automatically converts the dictionary to a JSON string before validation
-    @field_serializer("metadata")
-    def serialize_metadata(self, v: Optional[dict[str, Any]]) -> Optional[str]:
-        if v is None:
-            return None
-        return json.dumps(v)
 
 
 class Evidence(EvidenceBase):
@@ -36,14 +28,6 @@ class Evidence(EvidenceBase):
     paper_id: UUID
     created_at: datetime
     updated_at: datetime
-
-    # This validator automatically converts the JSON string from the DB back to a dictionary
-    @field_validator("metadata", mode="before")
-    @classmethod
-    def deserialize_metadata(cls, v: Any) -> Optional[dict[str, Any]]:
-        if isinstance(v, str):
-            return json.loads(v)
-        return v
 
     class Config:
         from_attributes = True

--- a/backend/app/models/ontology.py
+++ b/backend/app/models/ontology.py
@@ -15,6 +15,7 @@ class _AliasMixin(BaseModel):
     name: str = Field(..., min_length=1)
     aliases: list[str] = Field(default_factory=list)
     description: Optional[str] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class MethodBase(_AliasMixin):

--- a/backend/app/models/triple_candidate.py
+++ b/backend/app/models/triple_candidate.py
@@ -22,3 +22,4 @@ class TripleCandidateRecord:
     schema_match_score: float
     tier: str
     graph_metadata: Dict[str, Any] = field(default_factory=dict)
+    provenance: Dict[str, Any] = field(default_factory=dict)

--- a/backend/app/services/concepts.py
+++ b/backend/app/services/concepts.py
@@ -1,18 +1,59 @@
 from __future__ import annotations
 
-from typing import List, Optional, Sequence
+import json
+from typing import Any, List, Sequence
 from uuid import UUID
 
 from app.db.pool import get_pool
 from app.models.concept import Concept, ConceptCreate
 
 
-from typing import Optional
 INSERT_CONCEPT_QUERY = """
-    INSERT INTO concepts (paper_id, name, type, description)
-    VALUES ($1, $2, $3, $4)
-    RETURNING id, paper_id, name, type, description, created_at, updated_at
+    INSERT INTO concepts (paper_id, name, type, description, aliases, metadata)
+    VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)
+    RETURNING id, paper_id, name, type, description, aliases, metadata, created_at, updated_at
 """
+
+
+def _clean_aliases(raw_aliases: Any) -> list[str]:
+    if raw_aliases is None:
+        return []
+    if isinstance(raw_aliases, list):
+        return [alias.strip() for alias in raw_aliases if isinstance(alias, str) and alias.strip()]
+    if isinstance(raw_aliases, str):
+        try:
+            decoded = json.loads(raw_aliases)
+        except json.JSONDecodeError:
+            candidate = raw_aliases.strip()
+            return [candidate] if candidate else []
+        if isinstance(decoded, list):
+            return [alias.strip() for alias in decoded if isinstance(alias, str) and alias.strip()]
+        if isinstance(decoded, str):
+            candidate = decoded.strip()
+            return [candidate] if candidate else []
+    return []
+
+
+def _clean_metadata(raw_metadata: Any) -> dict[str, Any]:
+    if isinstance(raw_metadata, dict):
+        return dict(raw_metadata)
+    if raw_metadata is None:
+        return {}
+    if isinstance(raw_metadata, str):
+        try:
+            decoded = json.loads(raw_metadata)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(decoded, dict):
+            return dict(decoded)
+    return {}
+
+
+def _concept_from_row(row: Any) -> Concept:
+    payload = dict(row)
+    payload["aliases"] = _clean_aliases(payload.get("aliases"))
+    payload["metadata"] = _clean_metadata(payload.get("metadata"))
+    return Concept(**payload)
 
 
 async def list_concepts(
@@ -23,7 +64,7 @@ async def list_concepts(
 ) -> List[Concept]:
     pool = get_pool()
     query = """
-        SELECT id, paper_id, name, type, description, created_at, updated_at
+        SELECT id, paper_id, name, type, description, aliases, metadata, created_at, updated_at
         FROM concepts
         WHERE paper_id = $1
         ORDER BY name
@@ -31,7 +72,7 @@ async def list_concepts(
     """
     async with pool.acquire() as conn:
         rows = await conn.fetch(query, paper_id, limit, offset)
-    return [Concept(**dict(row)) for row in rows]
+    return [_concept_from_row(row) for row in rows]
 
 
 async def create_concept(data: ConceptCreate) -> Concept:
@@ -43,20 +84,22 @@ async def create_concept(data: ConceptCreate) -> Concept:
             data.name,
             data.type,
             data.description,
+            json.dumps(data.aliases),
+            json.dumps(data.metadata),
         )
-    return Concept(**dict(row))
+    return _concept_from_row(row)
 
 
 async def get_concept(concept_id: UUID) -> Optional[Concept]:
     pool = get_pool()
     query = """
-        SELECT id, paper_id, name, type, description, created_at, updated_at
+        SELECT id, paper_id, name, type, description, aliases, metadata, created_at, updated_at
         FROM concepts
         WHERE id = $1
     """
     async with pool.acquire() as conn:
         row = await conn.fetchrow(query, concept_id)
-    return Concept(**dict(row)) if row else None
+    return _concept_from_row(row) if row else None
 
 
 async def delete_concepts_for_paper(paper_id: UUID) -> None:
@@ -83,6 +126,8 @@ async def replace_concepts(
                     concept.name,
                     concept.type,
                     concept.description,
+                    json.dumps(concept.aliases),
+                    json.dumps(concept.metadata),
                 )
-                inserted.append(Concept(**dict(row)))
+                inserted.append(_concept_from_row(row))
     return inserted

--- a/backend/app/services/triple_candidates.py
+++ b/backend/app/services/triple_candidates.py
@@ -23,10 +23,11 @@ INSERT_SQL = """
         triple_conf,
         schema_match_score,
         tier,
-        graph_metadata
+        graph_metadata,
+        provenance
     )
     VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
     )
 """
 
@@ -79,6 +80,7 @@ async def replace_triple_candidates(
                         candidate.schema_match_score,
                         candidate.tier,
                         candidate.graph_metadata,
+                        candidate.provenance,
                     )
                 )
 


### PR DESCRIPTION
## Summary
- add a migration that moves ontology tables to JSONB metadata/alias storage, adds provenance fields, and converts claim categories to text
- update models and services to expose metadata/provenance on concepts, evidence, ontology entities, and triple candidates
- adjust service logic and unit tests to work with structured JSONB data instead of serialized text

## Testing
- pytest backend/tests/test_evidence_service.py backend/tests/test_triple_candidates_service.py backend/tests/test_concept_extraction.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e0a6624f308321b72c71ef88c00e8f