### PR TITLE
Add span provenance metadata to concept extraction

### DIFF
--- a/backend/app/models/section.py
+++ b/backend/app/models/section.py
@@ -5,9 +5,11 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-
 from typing import Optional
+
+
 class SectionBase(BaseModel):
+    id: Optional[UUID] = None
     title: Optional[str] = Field(default=None, max_length=512)
     content: str = Field(..., min_length=1)
     char_start: Optional[int] = Field(default=None, ge=0)

--- a/backend/app/services/concept_extraction.py
+++ b/backend/app/services/concept_extraction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 from uuid import UUID
 
 from app.core.config import settings
@@ -62,6 +62,33 @@ class ExtractedConcept:
     type: Optional[str]
     description: Optional[str]
     score: float
+    occurrences: int
+    provenance: List["ConceptProvenance"] = field(default_factory=list)
+
+
+@dataclass
+class ConceptProvenance:
+    section_id: Optional[UUID]
+    char_start: Optional[int]
+    char_end: Optional[int]
+    snippet: Optional[str]
+    provider: str
+    provider_metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "section_id": str(self.section_id) if self.section_id else None,
+            "char_start": self.char_start,
+            "char_end": self.char_end,
+            "snippet": self.snippet,
+            "provider": self.provider,
+            "provider_metadata": {
+                key: value
+                for key, value in self.provider_metadata.items()
+                if value is not None
+            },
+        }
+        return payload
 
 
 @dataclass
@@ -71,7 +98,11 @@ class _Candidate:
     type: Optional[str]
     description: Optional[str]
     score: float
-    occurrences: int = 1
+    provenance: List[ConceptProvenance] = field(default_factory=list)
+
+    @property
+    def occurrences(self) -> int:
+        return len(self.provenance)
 
 
 @dataclass
@@ -125,6 +156,8 @@ def extract_concepts_from_sections(
             type=candidate.type,
             description=candidate.description,
             score=round(_final_score(candidate), 4),
+            occurrences=candidate.occurrences,
+            provenance=list(candidate.provenance),
         )
         for candidate in top_ranked
     ]
@@ -143,7 +176,20 @@ def _collect_model_candidates(
             if model is None:
                 continue
             provider_available = True
-            collected.extend(_extract_with_spacy_model(model, sections, config))
+            model_meta = getattr(model, "meta", {}) or {}
+            provider_meta = {
+                "model": model_meta.get("name"),
+                "lang": getattr(model, "lang", None),
+            }
+            collected.extend(
+                _extract_with_spacy_model(
+                    model,
+                    sections,
+                    config,
+                    provider="scispacy",
+                    provider_metadata=provider_meta,
+                )
+            )
             break
         if normalized_provider == "domain_ner":
             if not config.domain_model:
@@ -152,7 +198,20 @@ def _collect_model_candidates(
             if model is None:
                 continue
             provider_available = True
-            collected.extend(_extract_with_spacy_model(model, sections, config))
+            model_meta = getattr(model, "meta", {}) or {}
+            provider_meta = {
+                "model": model_meta.get("name"),
+                "lang": getattr(model, "lang", None),
+            }
+            collected.extend(
+                _extract_with_spacy_model(
+                    model,
+                    sections,
+                    config,
+                    provider="domain_ner",
+                    provider_metadata=provider_meta,
+                )
+            )
             break
         if normalized_provider == "llm":
             if not _llm_prompt_available(config):
@@ -179,6 +238,7 @@ async def extract_and_store_concepts(
             name=concept.name,
             type=concept.type,
             description=concept.description,
+            metadata=_build_concept_metadata(concept),
         )
         for concept in concepts
     ]
@@ -332,7 +392,7 @@ def _merge_candidate(registry: Dict[str, _Candidate], candidate: _Candidate) -> 
         registry[candidate.normalized] = candidate
         return
     existing.score += candidate.score
-    existing.occurrences += candidate.occurrences
+    existing.provenance.extend(candidate.provenance)
     if candidate.type and (not existing.type or existing.type == "keyword"):
         existing.type = candidate.type
     if candidate.description and (
@@ -345,6 +405,19 @@ def _merge_candidate(registry: Dict[str, _Candidate], candidate: _Candidate) -> 
         candidate_words == existing_words and len(candidate.name) < len(existing.name)
     ):
         existing.name = candidate.name
+
+
+def _resolve_absolute_span(
+    section: SectionBase, local_start: Optional[int], local_end: Optional[int]
+) -> Tuple[Optional[int], Optional[int]]:
+    if local_start is None and local_end is None:
+        return None, None
+    base_offset = section.char_start or 0
+    if section.char_start is None:
+        return local_start, local_end
+    absolute_start = local_start + base_offset if local_start is not None else None
+    absolute_end = local_end + base_offset if local_end is not None else None
+    return absolute_start, absolute_end
 
 
 def _apply_method_post_filters(
@@ -380,6 +453,9 @@ def _extract_with_spacy_model(
     model: Language,
     sections: Sequence[SectionBase],
     config: ConceptExtractionRuntimeConfig,
+    *,
+    provider: str,
+    provider_metadata: Optional[Dict[str, Any]] = None,
 ) -> Iterable[_Candidate]:
     for section in sections:
         doc = model(section.content)
@@ -392,12 +468,33 @@ def _extract_with_spacy_model(
             description = _compose_description(section, snippet)
             label = (entity.label_ or "entity").lower()
             score = 4.0 + min(len(normalized.split()), 4)
+            absolute_start, absolute_end = _resolve_absolute_span(
+                section, entity.start_char, entity.end_char
+            )
+            metadata = dict(provider_metadata or {})
+            if getattr(entity, "label_", None):
+                metadata.setdefault("label", entity.label_)
+            kb_id = getattr(entity, "kb_id_", None)
+            if kb_id:
+                metadata["kb_id"] = kb_id
+            metadata["relative_span"] = [entity.start_char, entity.end_char]
+            provenance = ConceptProvenance(
+                section_id=getattr(section, "id", None),
+                char_start=absolute_start,
+                char_end=absolute_end,
+                snippet=snippet,
+                provider=provider,
+                provider_metadata={
+                    key: value for key, value in metadata.items() if value is not None
+                },
+            )
             yield _Candidate(
                 name=name,
                 normalized=normalized,
                 type=label,
                 description=description,
                 score=score,
+                provenance=[provenance],
             )
 
 
@@ -415,12 +512,26 @@ def _extract_with_heuristics(
             score = 1.0 + 0.3 * min(len(normalized.split()), 4)
             score += 0.2 if section.title else 0.0
             score += 0.4 if phrase.isupper() else 0.0
+            absolute_start, absolute_end = _resolve_absolute_span(section, start, end)
+            metadata = {
+                "strategy": "token_phrase",
+                "relative_span": [start, end],
+            }
+            provenance = ConceptProvenance(
+                section_id=getattr(section, "id", None),
+                char_start=absolute_start,
+                char_end=absolute_end,
+                snippet=snippet,
+                provider="heuristic",
+                provider_metadata=metadata,
+            )
             yield _Candidate(
                 name=_format_phrase(phrase),
                 normalized=normalized,
                 type=_infer_concept_type(phrase, entity_hints=config.entity_hints),
                 description=description,
                 score=score,
+                provenance=[provenance],
             )
 
 
@@ -711,6 +822,16 @@ def _infer_concept_type(
 
 def _final_score(candidate: _Candidate) -> float:
     return candidate.score + 0.2 * candidate.occurrences
+
+
+def _build_concept_metadata(concept: ExtractedConcept) -> Dict[str, Any]:
+    provenance_payload = [prov.to_payload() for prov in concept.provenance]
+    metadata: Dict[str, Any] = {
+        "occurrences": concept.occurrences,
+        "score": concept.score,
+        "provenance": provenance_payload,
+    }
+    return metadata
 
 
 def _load_scispacy_model(

--- a/backend/tests/test_concept_extraction.py
+++ b/backend/tests/test_concept_extraction.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from datetime import datetime, timezone
 from typing import List
 from uuid import UUID, uuid4
 
@@ -12,6 +11,7 @@ from app.models.paper import Paper
 from app.models.section import SectionCreate
 from app.services.concept_extraction import (
     _Candidate,
+    ConceptProvenance,
     _apply_method_post_filters,
     _infer_concept_type,
     extract_and_store_concepts,
@@ -26,6 +26,7 @@ def anyio_backend() -> str:
 
 def _make_section(content: str, *, title: str | None = None) -> SectionCreate:
     return SectionCreate(
+        id=uuid4(),
         paper_id=uuid4(),
         title=title,
         content=content,
@@ -86,6 +87,11 @@ def test_extract_concepts_from_sections_deduplicates_variants() -> None:
     assert len(mpnn_mentions) == 1
 
     assert any("cora dataset" in name for name in lowered)
+    assert all(concept.provenance for concept in concepts)
+    for concept in concepts:
+        provenance = concept.provenance[0]
+        assert provenance.provider in {"heuristic", "scispacy", "domain_ner"}
+        assert provenance.snippet
 
 
 def test_biology_domain_labels_organisms() -> None:
@@ -163,12 +169,14 @@ async def test_extract_and_store_concepts_persists_and_links(monkeypatch: pytest
 
     stored_models: List[Concept] = []
     captured_payloads: List[str] = []
+    captured_metadata: List[dict] = []
 
     async def fake_replace_concepts(
         _: UUID, models: List[ConceptCreate]
     ) -> List[Concept]:
-        nonlocal stored_models, captured_payloads
+        nonlocal stored_models, captured_payloads, captured_metadata
         captured_payloads = [model.name for model in models]
+        captured_metadata = [model.metadata for model in models]
         now = datetime.now(timezone.utc)
         stored_models = [
             Concept(
@@ -177,6 +185,7 @@ async def test_extract_and_store_concepts_persists_and_links(monkeypatch: pytest
                 name=model.name,
                 type=model.type,
                 description=model.description,
+                metadata=model.metadata,
                 created_at=now,
                 updated_at=now,
             )
@@ -214,6 +223,16 @@ async def test_extract_and_store_concepts_persists_and_links(monkeypatch: pytest
     lower_payloads = [name.lower() for name in captured_payloads]
     assert any("deep learning" in name for name in lower_payloads)
     assert any("cifar" in name for name in lower_payloads)
+    assert captured_metadata
+    for payload in captured_metadata:
+        assert payload["provenance"]
+        first = payload["provenance"][0]
+        assert first["provider"]
+        assert first["snippet"]
+        assert first["section_id"]
+        assert first["char_start"] is not None
+        assert first["char_end"] is not None
+        assert payload["occurrences"] >= 1
 
 
 def test_infer_concept_type_uses_strong_method_cues() -> None:
@@ -224,12 +243,21 @@ def test_infer_concept_type_uses_strong_method_cues() -> None:
 
 
 def test_method_post_filter_demotes_noisy_phrases() -> None:
+    provenance = ConceptProvenance(
+        section_id=None,
+        char_start=0,
+        char_end=10,
+        snippet="sample snippet",
+        provider="heuristic",
+        provider_metadata={"strategy": "token_phrase"},
+    )
     noisy = _Candidate(
         name="The Proposed Multi Stage Training Approach",
         normalized="proposed multi stage training approach",
         type="method",
         description=None,
         score=1.0,
+        provenance=[provenance],
     )
     corroborated = _Candidate(
         name="Baseline Transformer Model",
@@ -237,7 +265,7 @@ def test_method_post_filter_demotes_noisy_phrases() -> None:
         type="method",
         description=None,
         score=1.0,
-        occurrences=2,
+        provenance=[provenance, provenance],
     )
 
     registry = {


### PR DESCRIPTION
## Summary
- extend concept extraction candidates to capture section spans, snippets, and provider metadata
- include section identifiers on sections returned for extraction to support provenance
- persist concept provenance in stored metadata and update tests to verify the new payloads

## Testing
- pytest backend/tests/test_concept_extraction.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e112f0085483218817a606245cbba2