### PR TITLE
Add Tier-3 relation LLM fallback

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -302,6 +302,11 @@ class Settings(BaseSettings):
             "missing or spans cannot be resolved."
         )
     )
+    tier3_relation_fallback_enabled: bool = Field(default=False)
+    tier3_relation_fallback_min_rule_candidates: int = Field(default=3)
+    tier3_relation_fallback_prompt: Optional[str] = Field(default=None)
+    tier3_relation_fallback_max_attempts: int = Field(default=2)
+    tier3_relation_fallback_temperature: Optional[float] = Field(default=None)
     concept_extraction: ConceptExtractionSettings = Field(
         default_factory=ConceptExtractionSettings
     )

--- a/backend/app/services/extraction_tier3_relations.py
+++ b/backend/app/services/extraction_tier3_relations.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+from uuid import UUID, uuid4
+
+from app.core.config import settings
+from app.services import extraction_tier2 as tier2
+from app.services.extraction_tier2 import (
+    Tier2ValidationError,
+    TripleSchemaError,
+    validate_triples,
+)
+
+logger = logging.getLogger(__name__)
+
+FALLBACK_SOURCE = "tier3_llm"
+_DEFAULT_PROMPT = (
+    "Rule-based extraction produced too few relation triples. Identify additional "
+    "method, dataset, task, or metric relations that are explicitly supported by "
+    "the evidence. Return up to 6 high-confidence triples that obey the provided "
+    "JSON schema and avoid duplicates of the existing candidates."
+)
+
+
+def _non_fallback_rule_count(candidates: Sequence[dict[str, Any]]) -> int:
+    count = 0
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        source = str(candidate.get("source") or "").strip().lower()
+        tier = str(candidate.get("tier") or "").strip().lower()
+        if source == FALLBACK_SOURCE or tier == FALLBACK_SOURCE:
+            continue
+        count += 1
+    return count
+
+
+async def maybe_apply_relation_llm_fallback(
+    paper_id: UUID,
+    summary: dict[str, Any],
+    *,
+    enabled: Optional[bool] = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Optionally invoke an LLM to backfill relation triples when rules lack coverage."""
+
+    effective_enabled = settings.tier3_relation_fallback_enabled if enabled is None else bool(enabled)
+    candidates = list(summary.get("triple_candidates") or [])
+    sections = summary.get("sections") or []
+    threshold = max(0, int(settings.tier3_relation_fallback_min_rule_candidates or 0))
+    rule_count = _non_fallback_rule_count(candidates)
+
+    meta: dict[str, Any] = {
+        "enabled": effective_enabled,
+        "triggered": False,
+        "rule_candidates": rule_count,
+        "threshold": threshold,
+        "attempts": 0,
+        "accepted": 0,
+        "status": "disabled" if not effective_enabled else "skipped",
+        "errors": [],
+    }
+
+    if not effective_enabled:
+        return [], meta
+
+    if rule_count >= threshold and threshold > 0:
+        meta["status"] = "rule_coverage_sufficient"
+        return [], meta
+
+    if not sections:
+        meta.update({"triggered": True, "status": "no_sections"})
+        meta["errors"].append("No sections available for fallback context")
+        return [], meta
+
+    contexts = tier2._prepare_section_contexts(sections)
+    if not contexts:
+        meta.update({"triggered": True, "status": "no_context"})
+        meta["errors"].append("Unable to derive section contexts for fallback")
+        return [], meta
+
+    messages = tier2._build_messages(contexts)
+    prompt = settings.tier3_relation_fallback_prompt or _DEFAULT_PROMPT
+    if prompt:
+        for message in reversed(messages):
+            if message.get("role") == "user":
+                existing = message.get("content") or ""
+                message["content"] = f"{existing.rstrip()}\n\n{prompt.strip()}"
+                break
+
+    max_attempts = max(1, int(settings.tier3_relation_fallback_max_attempts or 1))
+    base_temperature = settings.tier3_relation_fallback_temperature
+
+    pending_messages: Sequence[dict[str, str]] = list(messages)
+    repair_context = None
+    temperature_override = base_temperature
+    errors: list[str] = []
+
+    for attempt in range(max_attempts):
+        meta.update({"triggered": True, "attempts": attempt + 1, "status": "in_progress"})
+        try:
+            raw_content = await tier2._invoke_llm(
+                pending_messages, temperature=temperature_override
+            )
+        except Tier2ValidationError as exc:
+            message = f"LLM request failed on attempt {attempt + 1}: {exc}"
+            logger.warning("[tier3] %s", message)
+            errors.append(message)
+            pending_messages = list(messages)
+            repair_context = None
+            temperature_override = base_temperature
+            continue
+
+        try:
+            candidate_payload = tier2._parse_json(raw_content)
+            if repair_context is not None:
+                candidate_payload = tier2._apply_repair_patch(repair_context, candidate_payload)
+                repair_context = None
+                pending_messages = list(messages)
+                temperature_override = base_temperature
+        except Tier2ValidationError as exc:
+            message = f"Fallback payload parse failed on attempt {attempt + 1}: {exc}"
+            logger.warning("[tier3] %s", message)
+            errors.append(message)
+            continue
+
+        try:
+            validated = validate_triples(candidate_payload)
+        except TripleSchemaError as exc:
+            message = (
+                f"Fallback payload schema violations on attempt {attempt + 1}: {exc}"
+            )
+            logger.warning("[tier3] %s", message)
+            errors.append(message)
+            if attempt + 1 >= max_attempts:
+                break
+            try:
+                pending_messages, repair_context, temperature_override = tier2._build_repair_messages(
+                    candidate_payload, exc.issues
+                )
+            except Tier2ValidationError as repair_exc:
+                repair_message = f"Failed to build repair prompt: {repair_exc}"
+                logger.warning("[tier3] %s", repair_message)
+                errors.append(repair_message)
+                repair_context = None
+                break
+            continue
+        except Tier2ValidationError as exc:
+            message = f"Fallback payload validation failed on attempt {attempt + 1}: {exc}"
+            logger.warning("[tier3] %s", message)
+            errors.append(message)
+            pending_messages = list(messages)
+            repair_context = None
+            temperature_override = base_temperature
+            continue
+
+        triples: list[dict[str, Any]] = []
+        for index, triple in enumerate(validated.triples):
+            triple_dict = triple.model_dump()
+            triple_dict["source"] = FALLBACK_SOURCE
+            triple_dict["tier"] = FALLBACK_SOURCE
+            triple_dict["provenance"] = FALLBACK_SOURCE
+            triple_dict["retry_count"] = attempt
+            triple_dict["fallback_attempt"] = attempt + 1
+            triple_dict.setdefault("evidence_spans", [])
+            triple_dict.setdefault(
+                "candidate_id",
+                f"{FALLBACK_SOURCE}_{paper_id.hex}_{attempt}_{index:03d}_{uuid4().hex[:8]}",
+            )
+            triples.append(triple_dict)
+
+        meta.update(
+            {
+                "status": "succeeded",
+                "accepted": len(triples),
+                "errors": list(dict.fromkeys(errors)),
+                "retry_used": attempt,
+            }
+        )
+        logger.info(
+            "[tier3] LLM fallback produced %s triples for paper %s on attempt %s",
+            len(triples),
+            paper_id,
+            attempt + 1,
+        )
+        return triples, meta
+
+    meta.update(
+        {
+            "status": "failed",
+            "errors": list(dict.fromkeys(errors)),
+        }
+    )
+    return [], meta
+
+
+__all__ = [
+    "FALLBACK_SOURCE",
+    "maybe_apply_relation_llm_fallback",
+]

--- a/backend/tests/test_tier3_relations_fallback.py
+++ b/backend/tests/test_tier3_relations_fallback.py
@@ -1,0 +1,162 @@
+import json
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.services.extraction_tier3_relations import (
+    FALLBACK_SOURCE,
+    maybe_apply_relation_llm_fallback,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _build_section(section_id: str, text: str) -> dict[str, object]:
+    return {
+        "section_id": section_id,
+        "section_hash": f"hash-{section_id}",
+        "page_number": 1,
+        "char_start": 0,
+        "char_end": len(text),
+        "sentence_spans": [
+            {
+                "start": 0,
+                "end": len(text),
+                "text": text,
+            }
+        ],
+    }
+
+
+@pytest.mark.anyio
+async def test_tier3_fallback_generates_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "tier3_relation_fallback_enabled", True)
+    monkeypatch.setattr(settings, "tier3_relation_fallback_min_rule_candidates", 2)
+    monkeypatch.setattr(settings, "tier3_relation_fallback_max_attempts", 2)
+
+    paper_id = uuid4()
+    summary = {
+        "sections": [
+            _build_section(
+                "sec-1",
+                "AlphaNet evaluates on CIFAR-10 and achieves 95.2% accuracy on the test set.",
+            )
+        ],
+        "triple_candidates": [],
+    }
+
+    payload = {
+        "triples": [
+            {
+                "subject": "AlphaNet",
+                "relation": "evaluated on",
+                "object": "CIFAR-10",
+                "evidence": "AlphaNet evaluates on CIFAR-10 and achieves 95.2% accuracy on the test set.",
+                "subject_span": [0, 8],
+                "object_span": [19, 27],
+                "relation_type_guess": "EVALUATED_ON",
+                "subject_type_guess": "Method",
+                "object_type_guess": "Dataset",
+                "section_id": "sec-1",
+                "chunk_id": "sec-1#chunk-01",
+            }
+        ],
+        "warnings": [],
+        "discarded": [],
+    }
+
+    async def fake_invoke(messages, *, temperature=None):  # type: ignore[override]
+        return json.dumps(payload)
+
+    monkeypatch.setattr(
+        "app.services.extraction_tier3_relations.tier2._invoke_llm",
+        fake_invoke,
+    )
+
+    candidates, meta = await maybe_apply_relation_llm_fallback(
+        paper_id,
+        summary,
+    )
+
+    assert meta["triggered"] is True
+    assert meta["status"] == "succeeded"
+    assert meta["accepted"] == 1
+    assert meta.get("errors") == []
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["source"] == FALLBACK_SOURCE
+    assert candidate["tier"] == FALLBACK_SOURCE
+    assert candidate["retry_count"] == 0
+    assert candidate["provenance"] == FALLBACK_SOURCE
+
+
+@pytest.mark.anyio
+async def test_tier3_fallback_retries_after_invalid_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "tier3_relation_fallback_enabled", True)
+    monkeypatch.setattr(settings, "tier3_relation_fallback_min_rule_candidates", 1)
+    monkeypatch.setattr(settings, "tier3_relation_fallback_max_attempts", 3)
+
+    paper_id = uuid4()
+    summary = {
+        "sections": [
+            _build_section(
+                "sec-2",
+                "BetaNet reports 87.4 F1 on the dev split of the CustomEval benchmark.",
+            )
+        ],
+        "triple_candidates": [],
+    }
+
+    valid_payload = {
+        "triples": [
+            {
+                "subject": "BetaNet",
+                "relation": "reports",
+                "object": "87.4 F1 on CustomEval dev",
+                "evidence": "BetaNet reports 87.4 F1 on the dev split of the CustomEval benchmark.",
+                "subject_span": [0, 7],
+                "object_span": [15, 40],
+                "relation_type_guess": "REPORTS",
+                "subject_type_guess": "Method",
+                "object_type_guess": "Metric",
+                "section_id": "sec-2",
+                "chunk_id": "sec-2#chunk-01",
+            }
+        ],
+        "warnings": [],
+        "discarded": [],
+    }
+
+    responses = iter([
+        "{",  # invalid JSON to trigger retry
+        json.dumps(valid_payload),
+    ])
+
+    async def fake_invoke(messages, *, temperature=None):  # type: ignore[override]
+        return next(responses)
+
+    monkeypatch.setattr(
+        "app.services.extraction_tier3_relations.tier2._invoke_llm",
+        fake_invoke,
+    )
+
+    candidates, meta = await maybe_apply_relation_llm_fallback(
+        paper_id,
+        summary,
+    )
+
+    assert meta["triggered"] is True
+    assert meta["status"] == "succeeded"
+    assert meta["attempts"] == 2
+    assert meta["accepted"] == 1
+    assert meta["errors"]
+
+    candidate = candidates[0]
+    assert candidate["retry_count"] == 1
+    assert candidate["fallback_attempt"] == 2
+    assert candidate["source"] == FALLBACK_SOURCE


### PR DESCRIPTION
## Summary
- introduce a Tier-3 relation fallback service that calls the structured LLM with schema validation, repair retries, and provenance metadata when rule coverage is low
- surface new fallback feature flags in settings, merge results in the Tier-3 verifier, and log activations from the parsing task
- add targeted tests covering successful fallback usage and retry handling on malformed payloads

## Testing
- pytest backend/tests/test_tier3_relations_fallback.py backend/tests/test_tier3_verifier.py *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68e1246138cc8321ba6952e7763590de