### PR TITLE
Add Tier-3 relations orchestrator

### DIFF
--- a/backend/app/models/triple_candidate.py
+++ b/backend/app/models/triple_candidate.py
@@ -23,3 +23,6 @@ class TripleCandidateRecord:
     tier: str
     graph_metadata: Dict[str, Any] = field(default_factory=dict)
     provenance: Dict[str, Any] = field(default_factory=dict)
+    verification: Dict[str, Any] = field(default_factory=dict)
+    confidence_components: Dict[str, Any] = field(default_factory=dict)
+    verifier_notes: Optional[str] = None

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,10 +1,20 @@
 """Pydantic schemas shared across application services."""
 
 from .tier2 import RelationGuess, TripleExtractionResponse, TriplePayload, TypeGuess
+from .tier3 import (
+    EvidenceSpanPayload,
+    NumericMeasurementPayload,
+    NumericRangePayload,
+    Tier3RelationCandidate,
+)
 
 __all__ = [
     "RelationGuess",
     "TripleExtractionResponse",
     "TriplePayload",
     "TypeGuess",
+    "EvidenceSpanPayload",
+    "NumericMeasurementPayload",
+    "NumericRangePayload",
+    "Tier3RelationCandidate",
 ]

--- a/backend/app/schemas/tier3.py
+++ b/backend/app/schemas/tier3.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class EvidenceSpanPayload(BaseModel):
+    """Sentence-level evidence span produced by Tier-3 models."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    section_id: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    sentence_index: Optional[int] = Field(default=None, ge=0)
+    start: Optional[int] = Field(default=None, ge=0)
+    end: Optional[int] = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _ensure_span_consistency(self) -> "EvidenceSpanPayload":
+        if self.start is None and self.end is None:
+            return self
+        if self.start is None or self.end is None or self.start > self.end:
+            msg = "Evidence spans must include both start and end offsets"
+            raise ValueError(msg)
+        return self
+
+
+class NumericRangePayload(BaseModel):
+    """Normalized numeric range associated with a measurement."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    minimum: float = Field(..., description="Lower bound of the reported range")
+    maximum: float = Field(..., description="Upper bound of the reported range")
+
+    @model_validator(mode="after")
+    def _ensure_order(self) -> "NumericRangePayload":
+        if self.minimum > self.maximum:
+            msg = "Numeric range minimum must be <= maximum"
+            raise ValueError(msg)
+        return self
+
+
+class NumericMeasurementPayload(BaseModel):
+    """Structured representation of a numeric result extracted in Tier-3."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    metric: str = Field(..., min_length=2, max_length=120)
+    value: float = Field(..., description="Primary numeric value extracted from evidence")
+    value_text: str = Field(..., min_length=1, max_length=48)
+    unit: Optional[str] = Field(default=None, max_length=16)
+    dataset: Optional[str] = Field(default=None, max_length=160)
+    split: Optional[str] = Field(default=None, max_length=60)
+    task: Optional[str] = Field(default=None, max_length=160)
+    confidence_interval: Optional[str] = Field(default=None, max_length=64)
+    normalization_hash: Optional[str] = Field(default=None, min_length=8, max_length=64)
+    value_range: Optional[NumericRangePayload] = Field(default=None)
+
+    @field_validator("metric")
+    @classmethod
+    def _normalize_metric(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            msg = "Metric name cannot be empty"
+            raise ValueError(msg)
+        return cleaned
+
+    @field_validator("unit")
+    @classmethod
+    def _normalize_unit(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        replacements = {
+            "percent": "%",
+            "percentage": "%",
+            "points": "points",
+            "pt": "points",
+        }
+        lowered = cleaned.lower()
+        if lowered in replacements:
+            return replacements[lowered]
+        return cleaned
+
+
+class Tier3RelationCandidate(BaseModel):
+    """Validated Tier-3 relation candidate returned by LLM fallbacks."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    subject: str = Field(..., min_length=2, max_length=160)
+    relation: str = Field(..., min_length=2, max_length=80)
+    object: str = Field(..., min_length=1, max_length=200)
+    evidence: str = Field(..., min_length=10, max_length=800)
+    evidence_spans: list[EvidenceSpanPayload] = Field(default_factory=list, max_length=16)
+    triple_conf: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    schema_match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    provenance: Optional[str] = Field(default=None, max_length=120)
+
+
+__all__ = [
+    "EvidenceSpanPayload",
+    "NumericMeasurementPayload",
+    "NumericRangePayload",
+    "Tier3RelationCandidate",
+]
+

--- a/backend/app/services/extraction_tier3_relations.py
+++ b/backend/app/services/extraction_tier3_relations.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any, Optional, Sequence
 from uuid import UUID, uuid4
 
 from app.core.config import settings
+from app.schemas.tier3 import Tier3RelationCandidate
 from app.services import extraction_tier2 as tier2
 from app.services.extraction_tier2 import (
     Tier2ValidationError,
@@ -167,6 +169,8 @@ async def maybe_apply_relation_llm_fallback(
                 "candidate_id",
                 f"{FALLBACK_SOURCE}_{paper_id.hex}_{attempt}_{index:03d}_{uuid4().hex[:8]}",
             )
+            # Ensure Tier-3 specific payloads adhere to our schema contract.
+            Tier3RelationCandidate.model_validate(triple_dict)
             triples.append(triple_dict)
 
         meta.update(
@@ -194,7 +198,67 @@ async def maybe_apply_relation_llm_fallback(
     return [], meta
 
 
+async def run_tier3_relations(
+    paper_id: UUID,
+    *,
+    base_summary: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    """Orchestrate Tier-3 relation processing for a paper."""
+
+    if base_summary is None:
+        raise ValueError("Tier-3 relations requires Tier-1 and Tier-2 summaries")
+
+    summary = copy.deepcopy(base_summary)
+
+    metadata_raw = summary.get("metadata")
+    metadata: dict[str, Any]
+    if isinstance(metadata_raw, dict):
+        metadata = dict(metadata_raw)
+    else:
+        metadata = {}
+    summary["metadata"] = metadata
+
+    # Ensure the triple candidate list is materialized so we can mutate safely.
+    existing_candidates = list(summary.get("triple_candidates") or [])
+    summary["triple_candidates"] = existing_candidates
+
+    # Track that Tier-3 processing has been attempted for this summary.
+    tiers = set(summary.get("tiers") or [])
+    tiers.update({1, 2, 3})
+    summary["tiers"] = sorted(tiers)
+
+    fallback_candidates: list[dict[str, Any]] = []
+    fallback_meta: dict[str, Any]
+    try:
+        fallback_candidates, fallback_meta = await maybe_apply_relation_llm_fallback(
+            paper_id,
+            summary,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        fallback_meta = {
+            "triggered": True,
+            "status": "error",
+            "errors": [str(exc)],
+        }
+
+    if fallback_candidates:
+        existing_candidates.extend(fallback_candidates)
+
+    tier3_meta = {
+        "tier": "tier3_relations",
+        "status": fallback_meta.get("status", "unknown"),
+        "added_candidates": len(fallback_candidates),
+        "total_candidates": len(existing_candidates),
+        "fallback": fallback_meta,
+    }
+
+    metadata["tier3_relations"] = tier3_meta
+
+    return summary
+
+
 __all__ = [
     "FALLBACK_SOURCE",
     "maybe_apply_relation_llm_fallback",
+    "run_tier3_relations",
 ]

--- a/backend/app/services/triple_candidates.py
+++ b/backend/app/services/triple_candidates.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Sequence
+from typing import Any, Sequence
 from uuid import UUID
 
 try:
@@ -78,6 +78,21 @@ async def replace_triple_candidates(
                 if section_uuid and section_uuid not in valid_section_ids:
                     section_uuid = None
 
+                provenance_payload = dict(candidate.provenance or {})
+                verifier_details: dict[str, Any] = {}
+                if candidate.verification:
+                    verifier_details["verification"] = candidate.verification
+                if candidate.confidence_components:
+                    verifier_details["confidence_components"] = candidate.confidence_components
+                if candidate.verifier_notes:
+                    verifier_details["notes"] = candidate.verifier_notes
+                if verifier_details:
+                    existing = provenance_payload.get("verifier")
+                    if isinstance(existing, dict):
+                        existing.update({k: v for k, v in verifier_details.items() if v})
+                    else:
+                        provenance_payload["verifier"] = verifier_details
+
                 records.append(
                     (
                         candidate.paper_id,
@@ -95,7 +110,7 @@ async def replace_triple_candidates(
                         candidate.schema_match_score,
                         candidate.tier,
                         candidate.graph_metadata,
-                        candidate.provenance,
+                        provenance_payload,
 
                     )
                 )

--- a/backend/tests/test_tier3_relations.py
+++ b/backend/tests/test_tier3_relations.py
@@ -1,0 +1,121 @@
+from uuid import uuid4
+
+import pytest
+
+from app.services.extraction_tier3_relations import run_tier3_relations
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_run_tier3_relations_appends_fallback_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_summary = {
+        "triple_candidates": [
+            {
+                "subject": "Baseline",
+                "relation": "evaluated on",
+                "object": "Dataset-X",
+                "evidence": "Baseline evaluated on Dataset-X with accuracy.",
+            }
+        ],
+        "metadata": {},
+        "tiers": [1, 2],
+    }
+
+    fallback_candidate = {
+        "subject": "AlphaNet",
+        "relation": "evaluated on",
+        "object": "CIFAR-10",
+        "evidence": "AlphaNet was evaluated on the CIFAR-10 benchmark dataset.",
+        "evidence_spans": [],
+    }
+
+    fallback_meta = {
+        "status": "succeeded",
+        "triggered": True,
+        "accepted": 1,
+        "errors": [],
+    }
+
+    async def fake_fallback(*args, **kwargs):  # type: ignore[override]
+        return [fallback_candidate], fallback_meta
+
+    monkeypatch.setattr(
+        "app.services.extraction_tier3_relations.maybe_apply_relation_llm_fallback",
+        fake_fallback,
+    )
+
+    result = await run_tier3_relations(paper_id=uuid4(), base_summary=base_summary)
+
+    assert result is not base_summary
+    assert len(result["triple_candidates"]) == 2
+    assert fallback_candidate in result["triple_candidates"]
+
+    meta = result["metadata"].get("tier3_relations")
+    assert meta["added_candidates"] == 1
+    assert meta["fallback"] == fallback_meta
+    assert meta["status"] == "succeeded"
+    assert result["tiers"] == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_tier3_relations_records_disabled_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_summary = {
+        "triple_candidates": [],
+    }
+
+    fallback_meta = {
+        "status": "disabled",
+        "enabled": False,
+        "triggered": False,
+        "accepted": 0,
+        "errors": [],
+    }
+
+    async def fake_fallback(*args, **kwargs):  # type: ignore[override]
+        return [], fallback_meta
+
+    monkeypatch.setattr(
+        "app.services.extraction_tier3_relations.maybe_apply_relation_llm_fallback",
+        fake_fallback,
+    )
+
+    result = await run_tier3_relations(paper_id=uuid4(), base_summary=base_summary)
+
+    assert result["triple_candidates"] == []
+    meta = result["metadata"]["tier3_relations"]
+    assert meta["fallback"] == fallback_meta
+    assert meta["status"] == "disabled"
+    assert meta["added_candidates"] == 0
+
+
+@pytest.mark.anyio
+async def test_run_tier3_relations_handles_fallback_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_summary = {
+        "triple_candidates": [],
+    }
+
+    async def fake_fallback(*args, **kwargs):  # type: ignore[override]
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "app.services.extraction_tier3_relations.maybe_apply_relation_llm_fallback",
+        fake_fallback,
+    )
+
+    result = await run_tier3_relations(paper_id=uuid4(), base_summary=base_summary)
+
+    fallback_meta = result["metadata"]["tier3_relations"]["fallback"]
+    assert fallback_meta["status"] == "error"
+    assert fallback_meta["errors"] == ["boom"]
+    assert result["metadata"]["tier3_relations"]["status"] == "error"
+
+
+@pytest.mark.anyio
+async def test_run_tier3_relations_requires_base_summary() -> None:
+    with pytest.raises(ValueError):
+        await run_tier3_relations(paper_id=uuid4(), base_summary=None)
+

--- a/backend/tests/test_triple_candidates_service.py
+++ b/backend/tests/test_triple_candidates_service.py
@@ -75,6 +75,10 @@ def _make_candidate(paper_id: UUID, *, section_id: str | None) -> TripleCandidat
         schema_match_score=0.75,
         tier="tier2",
         graph_metadata={},
+        provenance={},
+        verification={},
+        confidence_components={},
+        verifier_notes=None,
     )
 
 


### PR DESCRIPTION
## Summary
- add a Tier-3 relations orchestrator that merges fallback output, normalizes metadata, and guards against missing summaries
- ensure Tier-3 metadata captures fallback status, candidate counts, and errors for downstream consumers
- create async tests that cover success, disabled, error, and missing-summary paths for the new orchestrator

## Testing
- `pytest backend/tests/test_tier3_relations.py backend/tests/test_tier3_relations_fallback.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e1289db9748321b052781111bb472f