### PR TITLE
feat: generalize tier1 lexicon and enable LLM concept fallback

### DIFF
--- a/Frontend/components/graph-explorer.tsx
+++ b/Frontend/components/graph-explorer.tsx
@@ -31,7 +31,17 @@ type NodeType =
   | "organism"
   | "finding"
   | "process";
-type RelationType = "proposes" | "evaluates_on" | "reports" | "compares";
+type RelationType =
+  | "proposes"
+  | "evaluates_on"
+  | "reports"
+  | "compares"
+  | "uses"
+  | "causes"
+  | "part_of"
+  | "is_a"
+  | "outperforms"
+  | "assumes";
 
 type GraphNodeLink = {
   id: string;
@@ -173,7 +183,18 @@ const ALL_TYPES: NodeType[] = [
   "finding",
   "process",
 ];
-const ALL_RELATIONS: RelationType[] = ["proposes", "evaluates_on", "reports", "compares"];
+const ALL_RELATIONS: RelationType[] = [
+  "proposes",
+  "evaluates_on",
+  "reports",
+  "compares",
+  "uses",
+  "causes",
+  "part_of",
+  "is_a",
+  "outperforms",
+  "assumes",
+];
 
 const NODE_COLORS: Record<NodeType, string> = {
   method: "#0ea5e9",
@@ -192,6 +213,12 @@ const EDGE_COLORS: Record<RelationType, string> = {
   evaluates_on: "#22c55e",
   reports: "#8b5cf6",
   compares: "#64748b",
+  uses: "#0ea5e9",
+  causes: "#ef4444",
+  part_of: "#d946ef",
+  is_a: "#6366f1",
+  outperforms: "#10b981",
+  assumes: "#facc15",
 };
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
@@ -432,6 +459,18 @@ const formatRelationLabel = (relation: RelationType) => {
       return "Reports";
     case "compares":
       return "Compares";
+    case "uses":
+      return "Uses";
+    case "causes":
+      return "Causes";
+    case "part_of":
+      return "Part of";
+    case "is_a":
+      return "Is a";
+    case "outperforms":
+      return "Outperforms";
+    case "assumes":
+      return "Assumes";
     default:
       return relation;
   }

--- a/backend/app/data/biology_lexicon.json
+++ b/backend/app/data/biology_lexicon.json
@@ -1,0 +1,51 @@
+{
+  "domain": "biology",
+  "methods": [
+    {
+      "name": "CRISPR Gene Editing",
+      "aliases": ["CRISPR-Cas9", "CRISPR editing"],
+      "description": "Targeted genome editing using CRISPR-associated nucleases"
+    },
+    {
+      "name": "RNA Sequencing",
+      "aliases": ["RNA-Seq", "RNAseq"],
+      "description": "High-throughput sequencing of transcriptomes"
+    }
+  ],
+  "datasets": [
+    {
+      "name": "Gene Expression Omnibus",
+      "aliases": ["GEO"],
+      "description": "NCBI repository of functional genomics datasets"
+    },
+    {
+      "name": "Protein Data Bank",
+      "aliases": ["PDB"],
+      "description": "Database of biomolecular 3D structures"
+    }
+  ],
+  "metrics": [
+    {
+      "name": "Fold Change",
+      "aliases": ["log2 fold change", "FC"],
+      "description": "Ratio comparing treatment and control expression"
+    },
+    {
+      "name": "Sequence Coverage",
+      "aliases": ["Coverage"],
+      "description": "Proportion of a sequence observed in sequencing experiments"
+    }
+  ],
+  "tasks": [
+    {
+      "name": "Gene Regulation Analysis",
+      "aliases": ["Regulatory network inference"],
+      "description": "Studying transcriptional regulation mechanisms"
+    },
+    {
+      "name": "Protein Structure Prediction",
+      "aliases": ["Structure modelling"],
+      "description": "Inferring 3D conformation of proteins from sequence"
+    }
+  ]
+}

--- a/backend/app/data/default_lexicon.json
+++ b/backend/app/data/default_lexicon.json
@@ -1,0 +1,77 @@
+{
+  "domain": "general_science",
+  "methods": [
+    {
+      "name": "Random Forest",
+      "aliases": ["Random Forests", "RF classifier"],
+      "description": "Ensemble of decision trees trained with bootstrap aggregation"
+    },
+    {
+      "name": "Support Vector Machine",
+      "aliases": ["SVM", "Support Vector Machines"],
+      "description": "Margin-based classifier for linear and non-linear decision boundaries"
+    },
+    {
+      "name": "Graph Neural Network",
+      "aliases": ["GNN", "Graph Neural Networks"],
+      "description": "Neural architecture operating on graph-structured inputs"
+    }
+  ],
+  "datasets": [
+    {
+      "name": "ImageNet",
+      "aliases": ["ILSVRC", "ImageNet-1k"],
+      "description": "Large-scale dataset for image classification"
+    },
+    {
+      "name": "CIFAR-10",
+      "aliases": ["CIFAR10"],
+      "description": "Image classification dataset of 10 everyday object categories"
+    },
+    {
+      "name": "GLUE Benchmark",
+      "aliases": ["GLUE", "General Language Understanding Evaluation"],
+      "description": "Suite of NLP tasks for benchmarking language understanding"
+    }
+  ],
+  "metrics": [
+    {
+      "name": "Accuracy",
+      "aliases": ["Acc."],
+      "description": "Proportion of correct predictions"
+    },
+    {
+      "name": "F1 Score",
+      "aliases": ["F1", "F1-score"],
+      "description": "Harmonic mean of precision and recall"
+    },
+    {
+      "name": "Area Under ROC",
+      "aliases": ["ROC AUC", "AUC"],
+      "description": "Area under the receiver operating characteristic curve"
+    },
+    {
+      "name": "Mean Absolute Error",
+      "aliases": ["MAE"],
+      "unit": null,
+      "description": "Average absolute difference between predicted and observed values"
+    }
+  ],
+  "tasks": [
+    {
+      "name": "Image Classification",
+      "aliases": ["Image Recognition"],
+      "description": "Assigning labels to images"
+    },
+    {
+      "name": "Question Answering",
+      "aliases": ["QA"],
+      "description": "Answering natural-language questions given context"
+    },
+    {
+      "name": "Named Entity Recognition",
+      "aliases": ["NER"],
+      "description": "Extracting entity spans from unstructured text"
+    }
+  ]
+}

--- a/backend/app/data/materials_lexicon.json
+++ b/backend/app/data/materials_lexicon.json
@@ -1,0 +1,53 @@
+{
+  "domain": "materials",
+  "methods": [
+    {
+      "name": "Density Functional Theory",
+      "aliases": ["DFT", "Density-functional theory"],
+      "description": "Quantum mechanical modelling method for materials"
+    },
+    {
+      "name": "Additive Manufacturing",
+      "aliases": ["3D printing"],
+      "description": "Layer-by-layer fabrication of materials and parts"
+    }
+  ],
+  "datasets": [
+    {
+      "name": "Materials Project",
+      "aliases": ["MP database"],
+      "description": "Computed information on inorganic crystal structures"
+    },
+    {
+      "name": "AFLOW",
+      "aliases": ["AFLOWlib"],
+      "description": "Materials database of calculated properties"
+    }
+  ],
+  "metrics": [
+    {
+      "name": "Band Gap",
+      "aliases": ["Bandgap", "Energy gap"],
+      "unit": "eV",
+      "description": "Energy difference between valence and conduction bands"
+    },
+    {
+      "name": "Yield Strength",
+      "aliases": ["Yield stress"],
+      "unit": "MPa",
+      "description": "Stress at which a material begins to deform plastically"
+    }
+  ],
+  "tasks": [
+    {
+      "name": "Catalyst Screening",
+      "aliases": ["Catalysis design"],
+      "description": "Identifying catalysts with desired activity and stability"
+    },
+    {
+      "name": "Battery Cathode Optimization",
+      "aliases": ["Cathode design"],
+      "description": "Improving cathode materials for energy storage"
+    }
+  ]
+}

--- a/backend/app/services/concept_extraction.py
+++ b/backend/app/services/concept_extraction.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 import re
 import warnings
 import unicodedata
@@ -12,6 +14,7 @@ from app.models.concept import Concept, ConceptCreate
 from app.models.paper import Paper
 from app.models.section import Section, SectionBase
 from app.services.concepts import replace_concepts
+from app.services.domain_inference import infer_domain_key
 from app.services.papers import get_paper
 from app.services.relations import replace_paper_concept_relations
 from app.services.sections import list_sections
@@ -35,6 +38,15 @@ try:  # pragma: no cover - optional dependency
     from scispacy.linking import EntityLinker  # type: ignore[import]
 except ImportError:  # pragma: no cover - optional dependency
     EntityLinker = None  # type: ignore[assignment]
+
+
+try:  # pragma: no cover - optional dependency
+    import httpx  # type: ignore[import]
+except ImportError:  # pragma: no cover - optional dependency
+    httpx = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
 
 
 MIN_CHAR_LENGTH = 3
@@ -246,7 +258,7 @@ async def extract_and_store_concepts(
 
 def _build_runtime_config(paper: Optional[Paper]) -> ConceptExtractionRuntimeConfig:
     concept_settings = settings.concept_extraction
-    domain_key = _infer_domain_key(paper)
+    domain_key = infer_domain_key(paper)
     overrides = (
         concept_settings.domain_overrides.get(domain_key)
         if domain_key and concept_settings.domain_overrides
@@ -275,7 +287,9 @@ def _build_runtime_config(paper: Optional[Paper]) -> ConceptExtractionRuntimeCon
     if overrides and overrides.filler_suffixes:
         base_filler_suffixes.update(word.lower() for word in overrides.filler_suffixes)
 
-    llm_prompt = overrides.llm_prompt if overrides and overrides.llm_prompt else concept_settings.llm_prompt
+    llm_prompt = (
+        overrides.llm_prompt if overrides and overrides.llm_prompt else concept_settings.llm_prompt
+    )
 
     entity_hints: Dict[str, Set[str]] = {}
     if overrides and overrides.entity_hints:
@@ -297,52 +311,6 @@ def _build_runtime_config(paper: Optional[Paper]) -> ConceptExtractionRuntimeCon
     )
 
 
-def _infer_domain_key(paper: Optional[Paper]) -> Optional[str]:
-    if paper is None:
-        return None
-    fields = [paper.venue, paper.file_content_type, paper.title]
-    combined = " ".join(filter(None, (value or "" for value in fields))).strip()
-    if not combined:
-        return None
-    lowered = combined.lower()
-    biology_cues = (
-        "biology",
-        "biochem",
-        "genom",
-        "microbio",
-        "immun",
-        "cell",
-        "organism",
-        "protein",
-        "enzyme",
-        "med",
-    )
-    if any(cue in lowered for cue in biology_cues):
-        return "biology"
-
-    materials_cues = (
-        "material",
-        "materials",
-        "alloy",
-        "polymer",
-        "ceramic",
-        "perovskite",
-        "graphene",
-        "nanotube",
-        "battery",
-        "cathode",
-        "anode",
-        "electrode",
-        "composite",
-        "crystal",
-        "oxide",
-    )
-    if any(cue in lowered for cue in materials_cues):
-        return "materials"
-
-    return None
-
-
 def _llm_prompt_available(config: ConceptExtractionRuntimeConfig) -> bool:
     if not config.llm_prompt:
         return False
@@ -355,10 +323,213 @@ def _extract_with_llm(
     sections: Sequence[SectionBase],
     config: ConceptExtractionRuntimeConfig,
 ) -> List[_Candidate]:
-    # Placeholder hook for a future LLM-backed extractor. We currently
-    # require credentials to be configured before attempting to call an LLM.
-    # Without them, we fall back to heuristic extraction.
+    if not config.llm_prompt:
+        return []
+
+    if httpx is None:  # pragma: no cover - optional dependency guard
+        logger.warning("[concept_extraction] httpx is required for LLM extraction")
+        return []
+
+    model = settings.tier2_llm_model
+    if not model:
+        logger.warning("[concept_extraction] LLM extraction requested but no model configured")
+        return []
+
+    context = _prepare_llm_context(sections, config)
+    if not context:
+        return []
+
+    messages = [
+        {"role": "system", "content": config.llm_prompt.strip()},
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "domain": config.domain_key,
+                    "max_concepts": config.max_concepts,
+                    "sections": context,
+                },
+                ensure_ascii=False,
+            ),
+        },
+    ]
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": float(settings.tier2_llm_temperature),
+        "top_p": float(settings.tier2_llm_top_p),
+        "max_tokens": int(min(1024, getattr(settings, "tier2_llm_max_output_tokens", 1024) or 1024)),
+    }
+    if settings.tier2_llm_force_json:
+        payload["response_format"] = {"type": "json_object"}
+
+    headers = {"Content-Type": "application/json"}
+    if settings.openai_api_key:
+        headers["Authorization"] = f"Bearer {settings.openai_api_key}"
+
+    base_url = (settings.tier2_llm_base_url or "https://api.openai.com/v1").rstrip("/")
+    path = (settings.tier2_llm_completion_path or "/chat/completions").lstrip("/")
+    url = f"{base_url}/{path}"
+
+    timeout_seconds = float(getattr(settings, "tier2_llm_timeout_seconds", 120.0) or 120.0)
+
+    try:
+        with httpx.Client(timeout=timeout_seconds) as client:
+            response = client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+    except (httpx.HTTPError, ValueError) as exc:  # pragma: no cover - network failure path
+        logger.warning("[concept_extraction] LLM request failed: %s", exc)
+        return []
+
+    raw_content = _extract_llm_content(data)
+    if not raw_content:
+        return []
+
+    records = _parse_llm_concept_payload(raw_content)
+    if not records:
+        return []
+
+    default_snippet = context[0].get("text") if context else ""
+    candidates: List[_Candidate] = []
+    for record in records:
+        candidate = _record_to_candidate(record, config, default_snippet)
+        if candidate:
+            candidates.append(candidate)
+    return candidates
+
+
+def _prepare_llm_context(
+    sections: Sequence[SectionBase], config: ConceptExtractionRuntimeConfig
+) -> List[Dict[str, Any]]:
+    max_sections = int(getattr(settings, "tier2_llm_max_sections", 12) or 12)
+    section_char_limit = int(getattr(settings, "tier2_llm_max_section_chars", 1500) or 1500)
+    selected: List[Dict[str, Any]] = []
+
+    for section in sections[:max_sections]:
+        text = (section.content or "").strip()
+        if not text:
+            continue
+        cleaned = re.sub(r"\s+", " ", text)
+        snippet = cleaned[:section_char_limit]
+        if len(cleaned) > section_char_limit:
+            snippet = snippet.rstrip() + "…"
+        selected.append({"title": section.title, "text": snippet})
+    return selected
+
+
+def _extract_llm_content(payload: Dict[str, Any]) -> str:
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        message = first.get("message") if isinstance(first, dict) else None
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+    if isinstance(payload.get("content"), str):
+        return str(payload["content"])
+    return ""
+
+
+def _parse_llm_concept_payload(raw_content: str) -> List[Dict[str, Any]]:
+    raw_content = raw_content.strip()
+    if not raw_content:
+        return []
+
+    parsed: Any
+    try:
+        parsed = json.loads(raw_content)
+    except json.JSONDecodeError:
+        start = raw_content.find("{")
+        end = raw_content.rfind("}")
+        if start >= 0 and end > start:
+            fragment = raw_content[start : end + 1]
+            try:
+                parsed = json.loads(fragment)
+            except json.JSONDecodeError:
+                return []
+        else:
+            return []
+
+    if isinstance(parsed, dict):
+        concepts = parsed.get("concepts")
+        if isinstance(concepts, list):
+            return [item for item in concepts if isinstance(item, dict)]
+        if isinstance(concepts, dict):
+            return [concepts]
+        return [parsed]
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
     return []
+
+
+def _record_to_candidate(
+    record: Dict[str, Any],
+    config: ConceptExtractionRuntimeConfig,
+    default_snippet: str,
+) -> Optional[_Candidate]:
+    raw_name = str(record.get("name") or "").strip()
+    if not raw_name:
+        return None
+
+    formatted_name = _format_phrase(raw_name)
+    normalized = _normalize_concept_name(formatted_name, config)
+    if not normalized:
+        return None
+
+    description_value = record.get("description")
+    description = str(description_value).strip() if description_value else None
+
+    type_value = record.get("type")
+    concept_type = str(type_value).strip().lower() if isinstance(type_value, str) else None
+
+    score_value = record.get("score") or record.get("confidence")
+    try:
+        score = float(score_value)
+    except (TypeError, ValueError):
+        score = 2.5
+    if score <= 0:
+        score = 2.5
+
+    evidence = record.get("evidence")
+    snippet: Optional[str] = None
+    if isinstance(evidence, list) and evidence:
+        first = evidence[0]
+        if isinstance(first, str):
+            snippet = first
+    elif isinstance(evidence, str):
+        snippet = evidence
+    elif isinstance(record.get("snippet"), str):
+        snippet = str(record["snippet"]).strip()
+    if not snippet:
+        snippet = default_snippet
+
+    provenance = [
+        {
+            "provider": "llm",
+            "section_id": None,
+            "section_title": None,
+            "page": None,
+            "offset_start": None,
+            "offset_end": None,
+            "char_start": None,
+            "char_end": None,
+            "section_char_start": None,
+            "section_char_end": None,
+            "snippet": snippet,
+        }
+    ]
+
+    return _Candidate(
+        name=formatted_name,
+        normalized=normalized,
+        type=concept_type,
+        description=description,
+        score=score,
+        provenance=provenance,
+    )
 
 
 async def _load_sections_for_paper(paper_id: UUID) -> List[Section]:

--- a/backend/app/services/domain_inference.py
+++ b/backend/app/services/domain_inference.py
@@ -1,0 +1,81 @@
+"""Shared helpers for inferring coarse paper domains.
+
+These utilities are reused across the concept and signal extraction tiers so
+that both components make consistent decisions when selecting domain-specific
+resources such as lexicons or spaCy models.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.models.paper import Paper
+
+
+def infer_domain_key(paper: Optional[Paper]) -> Optional[str]:
+    """Return a coarse domain label inferred from the paper metadata.
+
+    The heuristics intentionally remain lightweight – they only look at readily
+    available metadata such as the title and venue so that the function can run
+    early in the pipeline before any heavy parsing occurs.  The returned key is
+    used to select domain-tuned lexicons or NLP models.  `None` is returned when
+    the heuristics cannot confidently assign a domain.
+    """
+
+    if paper is None:
+        return None
+
+    fields = [paper.venue, paper.file_content_type, paper.title]
+    combined = " ".join(filter(None, (value or "" for value in fields))).strip()
+    if not combined:
+        return None
+
+    lowered = combined.lower()
+
+    biology_cues = (
+        "biology",
+        "biochem",
+        "genom",
+        "microbio",
+        "immun",
+        "cell",
+        "organism",
+        "protein",
+        "enzyme",
+        "med",
+    )
+    if any(cue in lowered for cue in biology_cues):
+        return "biology"
+
+    materials_cues = (
+        "material",
+        "materials",
+        "alloy",
+        "polymer",
+        "ceramic",
+        "perovskite",
+        "graphene",
+        "nanotube",
+        "battery",
+        "cathode",
+        "anode",
+        "electrode",
+        "composite",
+        "crystal",
+        "oxide",
+    )
+    if any(cue in lowered for cue in materials_cues):
+        return "materials"
+
+    translation_cues = (
+        "translation",
+        "machine translation",
+        "mt workshop",
+        "wmt",
+        "multilingual benchmark",
+    )
+    if any(cue in lowered for cue in translation_cues):
+        return "machine_translation"
+
+    return None
+

--- a/backend/app/services/extraction_tier1.py
+++ b/backend/app/services/extraction_tier1.py
@@ -35,6 +35,7 @@ from app.services.ontology_store import (
 from app.services.papers import get_paper
 from app.services.sections import list_sections
 from app.services.storage import download_pdf_from_storage
+from app.services.domain_inference import infer_domain_key
 from app.utils.text_sanitize import sanitize_text
 
 try:  # pragma: no cover - optional dependency
@@ -45,20 +46,40 @@ except ImportError:  # pragma: no cover - optional dependency
 
 SNIPPET_WINDOW = 80
 DEFAULT_CONFIDENCE = 0.6
-
-RESULT_PATTERN = re.compile(
-    r"(?P<metric>BLEU|ROUGE(?:-L)?|METEOR|ChrF\+\+?|F1|Accuracy|Top-1)\s*(=|:)?\s*(?P<val>\d+(?:\.\d+)?)\s*(?P<suffix>%|pts|\s*points)?",
-    re.IGNORECASE,
+DEFAULT_RESULT_METRIC_TERMS = (
+    "accuracy",
+    "precision",
+    "recall",
+    "f1",
+    "f1 score",
+    "f1-score",
+    "auc",
+    "roc auc",
+    "map",
+    "ndcg",
+    "bleu",
+    "rouge",
+    "meteor",
+    "chrF",
+    "chrF++",
+    "top-1",
+    "top-5",
+    "mae",
+    "rmse",
+    "psnr",
+    "dice",
+    "iou",
 )
+
 EVALUATE_PATTERN = re.compile(
-    r"(?:evaluate(?:d)?|tested|trained|measured)"
-    r"(?:\s+[A-Za-z0-9\-]+){0,6}\s+on\s+"
+    r"(?:evaluate(?:d)?|evaluating|tested|test(?:ing)?|trained|training|measured|measuring|validated|validating|benchmarked)"
+    r"(?:\s+[A-Za-z0-9\-]+){0,6}\s+(?:on|against|using)\s+"
     r"(?P<dataset>[A-Za-z0-9\-\+\/ ]{2,}?)(?=(?:[,.;]"
-    r"|\s+(?:and|with|for|using|achiev(?:es|ing)?|reports?|showing|compared|where)\b|$))",
+    r"|\s+(?:and|with|for|using|achiev(?:es|ing)?|reports?|showing|compared|where|versus)\b|$))",
     re.IGNORECASE,
 )
 PROPOSE_PATTERN = re.compile(
-    r"we\s+(?:propose|introduce|present)\s+(?P<method>[A-Z0-9][A-Z0-9\-\+ ]{2,})",
+    r"we\s+(?:propose|introduce|present|develop|design|build)\s+(?P<method>[A-Z0-9][A-Z0-9\-\+ ]{2,})",
     re.IGNORECASE,
 )
 STATE_OF_THE_ART_PATTERN = re.compile(
@@ -351,6 +372,7 @@ class Tier1Lexicon:
         self._dataset_lookup = _build_lookup(self.datasets)
         self._metric_lookup = _build_lookup(self.metrics)
         self._task_lookup = _build_lookup(self.tasks)
+        self._result_pattern = _build_result_pattern(self.metrics)
 
     @classmethod
     def from_json(cls, payload: dict[str, Any]) -> Tier1Lexicon:
@@ -390,20 +412,111 @@ class Tier1Lexicon:
     def find_task_in_text(self, text: str) ->Optional[LexiconEntry]:
         return _find_best_match(self._task_lookup, text)
 
+    @property
+    def result_pattern(self) -> re.Pattern[str]:
+        return self._result_pattern
 
-_MT_LEXICON: Optional[Tier1Lexicon] = None
+
+_LEXICON_CACHE: dict[str, Tier1Lexicon] = {}
+_DOMAIN_ALIASES = {
+    "mt": "machine_translation",
+    "machine-translation": "machine_translation",
+    "machine_translation": "machine_translation",
+    "translation": "machine_translation",
+    "general": "general_science",
+    "general-science": "general_science",
+}
+_DOMAIN_FILE_OPTIONS = {
+    "machine_translation": ["machine_translation_lexicon.json", "mt_lexicon.json"],
+    "general_science": ["default_lexicon.json"],
+    "biology": ["biology_lexicon.json"],
+    "materials": ["materials_lexicon.json"],
+}
+_DEFAULT_LEXICON_FILES = ["default_lexicon.json", "mt_lexicon.json"]
+
+
+def _normalize_domain_key(domain: Optional[str]) -> str:
+    if not domain:
+        return "default"
+    normalized = re.sub(r"[^a-z0-9]+", "_", domain.strip().lower())
+    normalized = normalized.strip("_")
+    if not normalized:
+        return "default"
+    return _DOMAIN_ALIASES.get(normalized, normalized)
+
+
+def load_lexicon(domain: Optional[str] = None) -> Tier1Lexicon:
+    normalized = _normalize_domain_key(domain)
+    cached = _LEXICON_CACHE.get(normalized)
+    if cached is not None:
+        return cached
+
+    base_path = Path(__file__).resolve().parents[1] / "data"
+    search_files: list[str] = []
+    if normalized != "default":
+        search_files.extend(_DOMAIN_FILE_OPTIONS.get(normalized, []))
+    search_files.extend(_DEFAULT_LEXICON_FILES)
+
+    for filename in search_files:
+        path = base_path / filename
+        if not path.exists():
+            continue
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        lexicon = Tier1Lexicon.from_json(payload)
+        _LEXICON_CACHE[normalized] = lexicon
+        # Cache the default lexicon separately to avoid re-loading on future fallbacks.
+        if normalized != "default" and "domain" in payload:
+            fallback_key = _normalize_domain_key(payload.get("domain"))
+            _LEXICON_CACHE.setdefault(fallback_key, lexicon)
+        if normalized != "default" and filename in _DEFAULT_LEXICON_FILES:
+            _LEXICON_CACHE.setdefault("default", lexicon)
+        return lexicon
+
+    # If no file exists for the requested domain, fall back to the default cache if available.
+    default_lexicon = _LEXICON_CACHE.get("default")
+    if default_lexicon is not None:
+        _LEXICON_CACHE[normalized] = default_lexicon
+        return default_lexicon
+
+    fallback_name = _DEFAULT_LEXICON_FILES[0]
+    default_path = base_path / fallback_name
+    if not default_path.exists():
+        raise FileNotFoundError("Tier-1 lexicon files are missing from the data directory")
+    with default_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    lexicon = Tier1Lexicon.from_json(payload)
+    _LEXICON_CACHE["default"] = lexicon
+    _LEXICON_CACHE[normalized] = lexicon
+    return lexicon
 
 
 def load_mt_lexicon() -> Tier1Lexicon:
-    global _MT_LEXICON
-    if _MT_LEXICON is None:
-        path = Path(__file__).resolve().parents[1] / "data" / "mt_lexicon.json"
-        with path.open("r", encoding="utf-8") as handle:
-            payload = json.load(handle)
-        _MT_LEXICON = Tier1Lexicon.from_json(payload)
-    return _MT_LEXICON
+    return load_lexicon("machine_translation")
 
 
+def _build_result_pattern(metrics: Sequence[LexiconEntry]) -> re.Pattern[str]:
+    metric_terms: set[str] = set(DEFAULT_RESULT_METRIC_TERMS)
+    for entry in metrics:
+        for phrase in entry.phrases:
+            cleaned = phrase.strip()
+            if cleaned:
+                metric_terms.add(cleaned)
+
+    sorted_terms = sorted(metric_terms, key=lambda value: (-len(value), value.lower()))
+    escaped_terms = [re.escape(term) for term in sorted_terms if term]
+    if not escaped_terms:
+        escaped_terms = [r"[A-Za-z][A-Za-z0-9_\-]{2,}"]
+    metric_group = "|".join(escaped_terms)
+
+    value_pattern = r"[-+]?\d+(?:\.\d+)?(?:e[-+]?\d+)?"
+    suffix_pattern = r"%|percent|pts?|pp|percentage points|score|db"
+    pattern = re.compile(
+        rf"(?P<metric>{metric_group})\s*(?:=|:|≈|~|was|is|of|score(?:s)?|achieve(?:s|d)?|reaches|yields|at)?\s*"
+        rf"(?P<val>{value_pattern})\s*(?P<suffix>{suffix_pattern})?",
+        re.IGNORECASE,
+    )
+    return pattern
 
 
 def _clean_section_text(section: Section) -> str:
@@ -463,7 +576,7 @@ def extract_signals(
     lexicon: Optional[Tier1Lexicon] = None,
     table_texts: Optional[Sequence[str | TableRecord]] = None,
 ) -> Tier1Artifacts:
-    lexicon = lexicon or load_mt_lexicon()
+    lexicon = lexicon or load_lexicon()
     artifacts = Tier1Artifacts()
 
     text_sources: list[tuple[Optional[Section], str, str]] = []
@@ -506,11 +619,13 @@ async def run_tier1_extraction(
     lexicon: Optional[Tier1Lexicon] = None,
     table_texts: Optional[Sequence[str]] = None,
 ) -> dict[str, Any]:
-    lexicon = lexicon or load_mt_lexicon()
-
     paper = await get_paper(paper_id)
     if paper is None:
         raise ValueError(f"Paper {paper_id} does not exist")
+
+    if lexicon is None:
+        domain_key = infer_domain_key(paper)
+        lexicon = load_lexicon(domain_key)
 
     sections = await list_sections(paper_id=paper_id, limit=500, offset=0)
 
@@ -1263,7 +1378,7 @@ def _extract_results_from_text(
     results: list[DetectedResult] = []
     context_start = 0
     context_end = len(text)
-    for match in RESULT_PATTERN.finditer(text):
+    for match in lexicon.result_pattern.finditer(text):
         metric_phrase = match.group("metric")
         metric_entry = lexicon.lookup_metric(metric_phrase) or lexicon.find_metric_in_text(metric_phrase)
         if metric_entry:


### PR DESCRIPTION
## Summary
- generalize Tier-1 signal extraction to load domain-specific lexicons, add default/biology/materials lexicon data, and extend metric detection heuristics
- add a shared domain inference helper and implement the concept extractor's LLM fallback using httpx with robust JSON parsing
- expose all ontology relation types in the graph explorer UI with updated colors and labels

## Testing
- pytest backend/tests/test_concept_extraction.py *(fails: ModuleNotFoundError: fastapi)*
- python -m compileall backend/app/services/domain_inference.py backend/app/services/concept_extraction.py backend/app/services/extraction_tier1.py

------
https://chatgpt.com/codex/tasks/task_e_68e21313c2388321aa1f54fd3e37343e