### PR TITLE
Clarify compare workflow domain agnosticism

### DIFF
--- a/Frontend/app/compare/page.tsx
+++ b/Frontend/app/compare/page.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import type { ChangeEvent, ComponentType } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { AlertCircle, ArrowRightLeft, CheckCircle2, Loader2, RefreshCw, Table2 } from "lucide-react";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const detail = error.response?.data?.detail;
+    if (typeof detail === "string") {
+      return detail;
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+};
+
+export type ComparisonPaper = {
+  id: string;
+  title: string | null;
+  year: number | null;
+};
+
+export type ComparisonEntitySummary = {
+  shared: string[];
+  unique: Record<string, string[]>;
+};
+
+export type ComparisonSummary = {
+  methods: ComparisonEntitySummary;
+  datasets: ComparisonEntitySummary;
+  metrics: ComparisonEntitySummary;
+  tasks: ComparisonEntitySummary;
+};
+
+export type EvidenceItem = {
+  snippet?: string;
+  page?: number;
+  [key: string]: unknown;
+};
+
+export type ComparisonCell = {
+  result_id: string;
+  value_numeric: number | null;
+  value_text: string | null;
+  unit: string | null;
+  is_sota: boolean | null;
+  confidence: number | null;
+  evidence: EvidenceItem[];
+};
+
+export type ComparisonRow = {
+  method_id: string | null;
+  method_name: string | null;
+  dataset_id: string | null;
+  dataset_name: string | null;
+  metric_id: string | null;
+  metric_name: string | null;
+  metric_unit: string | null;
+  task_id: string | null;
+  task_name: string | null;
+  split: string | null;
+  papers: Record<string, ComparisonCell>;
+};
+
+export type PaperComparisonResponse = {
+  papers: ComparisonPaper[];
+  summary: ComparisonSummary;
+  matrix: ComparisonRow[];
+};
+
+export type PaperListItem = {
+  id: string;
+  title: string | null;
+  year: number | null;
+};
+
+const formatPaperLabel = (paper: PaperListItem) => {
+  const suffix = paper.year ? ` (${paper.year})` : "";
+  const title = paper.title ?? "Untitled paper";
+  return `${title}${suffix}`;
+};
+
+const formatValue = (cell: ComparisonCell) => {
+  if (cell.value_text) {
+    return cell.value_text;
+  }
+  if (typeof cell.value_numeric === "number") {
+    const value = cell.value_numeric.toLocaleString(undefined, {
+      maximumFractionDigits: 4,
+      minimumFractionDigits: Number.isInteger(cell.value_numeric) ? 0 : 2,
+    });
+    return cell.unit ? `${value} ${cell.unit}` : value;
+  }
+  return "—";
+};
+
+const EvidenceList = ({ evidence }: { evidence: EvidenceItem[] }) => {
+  if (!evidence?.length) {
+    return null;
+  }
+
+  return (
+    <ul className="mt-2 space-y-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 p-3 text-xs text-muted-foreground">
+      {evidence.slice(0, 3).map((item, index) => {
+        const snippet = typeof item.snippet === "string" ? item.snippet : null;
+        const page = typeof item.page === "number" ? item.page : undefined;
+        return (
+          <li key={index}>
+            {snippet ? <p className="line-clamp-3">{snippet}</p> : <p>Referenced evidence snippet</p>}
+            {page !== undefined ? <p className="mt-1 font-medium text-foreground">Page {page}</p> : null}
+          </li>
+        );
+      })}
+      {evidence.length > 3 ? (
+        <li className="text-[11px] italic text-muted-foreground">+{evidence.length - 3} more evidence items</li>
+      ) : null}
+    </ul>
+  );
+};
+
+const SummarySection = ({
+  label,
+  icon: Icon,
+  entity,
+  papers,
+}: {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  entity: ComparisonEntitySummary;
+  papers: ComparisonPaper[];
+}) => (
+  <div className="rounded-lg border bg-card p-4 shadow-sm">
+    <div className="flex items-center gap-2">
+      <span className="rounded-md bg-primary/10 p-2 text-primary">
+        <Icon className="h-4 w-4" />
+      </span>
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wide text-primary">{label}</p>
+        <p className="text-sm text-muted-foreground">Shared vs. unique coverage</p>
+      </div>
+    </div>
+    <div className="mt-4 space-y-3 text-sm">
+      <div>
+        <p className="font-semibold text-foreground">Shared</p>
+        {entity.shared.length ? (
+          <ul className="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
+            {entity.shared.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-1 text-muted-foreground">No shared items captured yet.</p>
+        )}
+      </div>
+      <div>
+        <p className="font-semibold text-foreground">What’s unique</p>
+        {papers.map((paper) => {
+          const entries = entity.unique[paper.id] ?? [];
+          return (
+            <div key={paper.id} className="mt-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{paper.title ?? paper.id}</p>
+              {entries.length ? (
+                <ul className="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
+                  {entries.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-1 text-muted-foreground">No unique items recorded.</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </div>
+);
+
+const ComparisonTable = ({
+  rows,
+  papers,
+}: {
+  rows: ComparisonRow[];
+  papers: ComparisonPaper[];
+}) => {
+  if (!rows.length) {
+    return (
+      <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No extracted results to compare yet. Trigger extraction to populate the matrix.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
+      <table className="min-w-full divide-y divide-border text-sm">
+        <thead className="bg-muted/40 text-left text-xs uppercase text-muted-foreground">
+          <tr>
+            <th scope="col" className="px-4 py-3 font-semibold">Dataset</th>
+            <th scope="col" className="px-4 py-3 font-semibold">Metric</th>
+            <th scope="col" className="px-4 py-3 font-semibold">Method</th>
+            <th scope="col" className="px-4 py-3 font-semibold">Task</th>
+            <th scope="col" className="px-4 py-3 font-semibold">Split</th>
+            {papers.map((paper) => (
+              <th key={paper.id} scope="col" className="px-4 py-3 font-semibold">
+                {paper.title ?? paper.id}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border text-sm">
+          {rows.map((row, index) => (
+            <tr key={index}>
+              <td className="px-4 py-3 align-top font-medium text-foreground">{row.dataset_name ?? "—"}</td>
+              <td className="px-4 py-3 align-top text-muted-foreground">
+                <div className="space-y-1">
+                  <p>{row.metric_name ?? "—"}</p>
+                  {row.metric_unit ? <p className="text-xs">Unit: {row.metric_unit}</p> : null}
+                </div>
+              </td>
+              <td className="px-4 py-3 align-top text-muted-foreground">{row.method_name ?? "—"}</td>
+              <td className="px-4 py-3 align-top text-muted-foreground">{row.task_name ?? "—"}</td>
+              <td className="px-4 py-3 align-top text-muted-foreground">{row.split ?? "—"}</td>
+              {papers.map((paper) => {
+                const cell = row.papers[paper.id];
+                return (
+                  <td key={paper.id} className="px-4 py-3 align-top">
+                    {cell ? (
+                      <div className="space-y-2">
+                        <div>
+                          <p className="font-semibold text-foreground">{formatValue(cell)}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                            {cell.is_sota ? (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 font-medium text-emerald-700">
+                                <CheckCircle2 className="h-3 w-3" /> SOTA
+                              </span>
+                            ) : null}
+                            {typeof cell.confidence === "number" ? (
+                              <span className="rounded-full bg-muted px-2 py-0.5">Confidence {(cell.confidence * 100).toFixed(0)}%</span>
+                            ) : null}
+                          </div>
+                        </div>
+                        <EvidenceList evidence={cell.evidence} />
+                      </div>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default function ComparePage() {
+  const [papers, setPapers] = useState<PaperListItem[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [comparison, setComparison] = useState<PaperComparisonResponse | null>(null);
+
+  const fetchPapers = useCallback(async () => {
+    try {
+      const response = await axios.get<PaperListItem[]>(`${API_BASE_URL}/api/papers`, {
+        params: { limit: 200 },
+      });
+      const sorted = [...response.data].sort((a, b) => {
+        const titleA = a.title?.toLowerCase() ?? "";
+        const titleB = b.title?.toLowerCase() ?? "";
+        if (titleA === titleB) {
+          return 0;
+        }
+        return titleA < titleB ? -1 : 1;
+      });
+      setPapers(sorted);
+      setError(null);
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to load papers for comparison."));
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPapers();
+  }, [fetchPapers]);
+
+  const refreshComparison = useCallback(
+    async (paperIds: string[]) => {
+      if (paperIds.length < 2) {
+        setComparison(null);
+        return;
+      }
+
+      setIsRefreshing(true);
+      setError(null);
+      try {
+        const response = await axios.get<PaperComparisonResponse>(`${API_BASE_URL}/api/compare`, {
+          params: { papers: paperIds.join(",") },
+        });
+        setComparison(response.data);
+      } catch (err) {
+        setError(getErrorMessage(err, "Unable to compute comparison. Please try again."));
+      } finally {
+        setIsRefreshing(false);
+      }
+    },
+    []
+  );
+
+  const handleSelectionChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const options = Array.from(event.target.selectedOptions).map((option) => option.value);
+      setSelected(options);
+      void refreshComparison(options);
+    },
+    [refreshComparison]
+  );
+
+  const handleRefreshClick = useCallback(() => {
+    if (selected.length >= 2) {
+      setIsLoading(true);
+      void refreshComparison(selected).finally(() => setIsLoading(false));
+    }
+  }, [refreshComparison, selected]);
+
+  const comparisonPapers = useMemo(() => comparison?.papers ?? [], [comparison]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary">Compare Papers</p>
+        <h1 className="text-2xl font-semibold text-foreground">Spot shared findings and fresh contributions</h1>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Select at least two papers—whether they come from machine learning, biology, chemistry, physics, or any other
+          discipline—to see overlapping methods, datasets, and metrics. The comparison matrix simply reflects the structured
+          results we store, so it stays domain agnostic while still surfacing supporting evidence snippets.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-lg border bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="paper-selection" className="text-sm font-medium text-foreground">
+            Choose papers
+          </label>
+          <select
+            id="paper-selection"
+            multiple
+            value={selected}
+            onChange={handleSelectionChange}
+            className="h-40 min-w-[16rem] rounded-md border border-border bg-background p-2 text-sm shadow-inner focus:border-primary focus:outline-none"
+          >
+            {papers.map((paper) => (
+              <option key={paper.id} value={paper.id}>
+                {formatPaperLabel(paper)}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-muted-foreground">Hold Ctrl/Cmd to pick multiple entries.</p>
+        </div>
+        <div className="flex flex-col items-start gap-2 md:items-end">
+          <button
+            type="button"
+            onClick={handleRefreshClick}
+            disabled={selected.length < 2 || isLoading}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground shadow transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted"
+          >
+            {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRightLeft className="h-4 w-4" />}
+            Run comparison
+          </button>
+          {isRefreshing ? (
+            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+              <RefreshCw className="h-3 w-3 animate-spin" /> Updating comparison
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="flex items-start gap-3 rounded-lg border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+          <AlertCircle className="mt-0.5 h-4 w-4" />
+          <p>{error}</p>
+        </div>
+      ) : null}
+
+      {comparison ? (
+        <>
+          <section className="grid gap-4 lg:grid-cols-2">
+            <SummarySection label="Methods" icon={Table2} entity={comparison.summary.methods} papers={comparisonPapers} />
+            <SummarySection label="Datasets" icon={Table2} entity={comparison.summary.datasets} papers={comparisonPapers} />
+            <SummarySection label="Metrics" icon={Table2} entity={comparison.summary.metrics} papers={comparisonPapers} />
+            <SummarySection label="Tasks" icon={Table2} entity={comparison.summary.tasks} papers={comparisonPapers} />
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-foreground">Extracted result matrix</h2>
+                <p className="text-sm text-muted-foreground">
+                  Compare metric values across the selected papers. Evidence snippets show where each claim was found.
+                </p>
+              </div>
+            </div>
+            <ComparisonTable rows={comparison.matrix} papers={comparisonPapers} />
+          </section>
+        </>
+      ) : (
+        <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/20 p-6 text-sm text-muted-foreground">
+          Select at least two papers to generate a comparison. Results and summaries will appear here.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Frontend/components/sidebar.tsx
+++ b/Frontend/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import {
   Database,
   FileText,
+  GitCompare,
   LayoutDashboard,
   Settings,
   Share2,
@@ -14,6 +15,7 @@ import {
 const navigation = [
   { name: "Overview", href: "/", icon: LayoutDashboard },
   { name: "Graph", href: "/graph", icon: Share2 },
+  { name: "Compare", href: "/compare", icon: GitCompare },
   { name: "Datasets", href: "/datasets", icon: Database },
   { name: "Papers", href: "/papers", icon: FileText },
   { name: "Ingestion", href: "/ingestion", icon: UploadCloud },

--- a/backend/app/api/compare.py
+++ b/backend/app/api/compare.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.compare import PaperComparisonResponse
+from app.services.compare import PaperComparisonError, compare_papers
+
+router = APIRouter(prefix="/compare", tags=["compare"])
+
+
+@router.get("", response_model=PaperComparisonResponse)
+async def compare_papers_endpoint(papers: str = Query(..., description="Comma-separated list of paper UUIDs")) -> PaperComparisonResponse:
+    paper_ids = _parse_paper_ids(papers)
+    try:
+        return await compare_papers(paper_ids)
+    except PaperComparisonError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _parse_paper_ids(raw: str) -> List[UUID]:
+    segments = [segment.strip() for segment in raw.split(",") if segment.strip()]
+    if not segments:
+        raise HTTPException(status_code=400, detail="At least two paper identifiers must be provided.")
+
+    try:
+        paper_ids = [UUID(segment) for segment in segments]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="One or more paper identifiers are invalid UUIDs.") from exc
+
+    if len(paper_ids) < 2:
+        raise HTTPException(status_code=400, detail="At least two paper identifiers must be provided.")
+
+    return paper_ids

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from app.db.database import test_postgres_connection
 from app.services.embeddings import ensure_vector_store_ready
 from app.services.storage import ensure_bucket_exists
 from app.api.admin import router as admin_router
+from app.api.compare import router as compare_router
 from app.api.concepts import router as concepts_router
 from app.api.evidence import router as evidence_router
 from app.api.extraction import router as extraction_router
@@ -98,6 +99,7 @@ def create_app() -> FastAPI:
     app.include_router(evidence_router, prefix=settings.api_prefix)
     app.include_router(search_router, prefix=settings.api_prefix)
     app.include_router(graph_router, prefix=settings.api_prefix)
+    app.include_router(compare_router, prefix=settings.api_prefix)
     app.include_router(extraction_router, prefix=settings.api_prefix)
     app.include_router(admin_router, prefix=settings.api_prefix)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,12 @@
 
+from .compare import (
+    ComparisonCell,
+    ComparisonEntitySummary,
+    ComparisonPaper,
+    ComparisonRow,
+    ComparisonSummary,
+    PaperComparisonResponse,
+)
 from .concept import Concept, ConceptBase, ConceptCreate
 from .evidence import Evidence, EvidenceBase, EvidenceCreate
 from .ontology import (
@@ -91,4 +99,10 @@ __all__ = [
     "ConceptResolutionBase",
     "ConceptResolutionCreate",
     "ConceptResolutionType",
+    "ComparisonCell",
+    "ComparisonEntitySummary",
+    "ComparisonPaper",
+    "ComparisonRow",
+    "ComparisonSummary",
+    "PaperComparisonResponse",
 ]

--- a/backend/app/models/compare.py
+++ b/backend/app/models/compare.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ComparisonPaper(BaseModel):
+    id: UUID
+    title: Optional[str] = None
+    year: Optional[int] = Field(default=None, ge=1800, le=2100)
+
+
+class ComparisonEntitySummary(BaseModel):
+    shared: List[str] = Field(default_factory=list)
+    unique: Dict[UUID, List[str]] = Field(default_factory=dict)
+
+
+class ComparisonSummary(BaseModel):
+    methods: ComparisonEntitySummary
+    datasets: ComparisonEntitySummary
+    metrics: ComparisonEntitySummary
+    tasks: ComparisonEntitySummary
+
+
+class ComparisonCell(BaseModel):
+    result_id: UUID
+    value_numeric: Optional[float] = None
+    value_text: Optional[str] = None
+    unit: Optional[str] = None
+    is_sota: Optional[bool] = None
+    confidence: Optional[float] = None
+    evidence: List[Mapping[str, Any]] = Field(default_factory=list)
+
+
+class ComparisonRow(BaseModel):
+    method_id: Optional[UUID] = None
+    method_name: Optional[str] = None
+    dataset_id: Optional[UUID] = None
+    dataset_name: Optional[str] = None
+    metric_id: Optional[UUID] = None
+    metric_name: Optional[str] = None
+    metric_unit: Optional[str] = None
+    task_id: Optional[UUID] = None
+    task_name: Optional[str] = None
+    split: Optional[str] = None
+    papers: Dict[UUID, ComparisonCell] = Field(default_factory=dict)
+
+
+class PaperComparisonResponse(BaseModel):
+    papers: List[ComparisonPaper]
+    summary: ComparisonSummary
+    matrix: List[ComparisonRow]
+
+    class Config:
+        json_encoders = {UUID: str}

--- a/backend/app/services/compare.py
+++ b/backend/app/services/compare.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, cast
+from uuid import UUID
+
+from app.db.pool import get_pool
+from app.models.compare import (
+    ComparisonCell,
+    ComparisonEntitySummary,
+    ComparisonPaper,
+    ComparisonRow,
+    ComparisonSummary,
+    PaperComparisonResponse,
+)
+
+
+class PaperComparisonError(ValueError):
+    """Raised when the comparison request cannot be fulfilled."""
+
+
+async def compare_papers(paper_ids: Sequence[UUID]) -> PaperComparisonResponse:
+    """Build a comparison across papers without assuming a particular domain.
+
+    Every result row is interpreted using the canonical method, dataset, metric,
+    and task tables so multi-disciplinary corpora (e.g., chemistry, biology,
+    physics, or ML) are handled uniformly. The function simply aggregates the
+    normalized entities already stored for each paper, which keeps the workflow
+    domain agnostic.
+    """
+
+    if len(paper_ids) < 2:
+        raise PaperComparisonError("At least two paper identifiers are required for comparison.")
+
+    unique_ids = list(dict.fromkeys(paper_ids))
+    pool = get_pool()
+
+    async with pool.acquire() as conn:
+        paper_rows = await conn.fetch(
+            "SELECT id, title, year FROM papers WHERE id = ANY($1::uuid[])",
+            unique_ids,
+        )
+
+        found_papers: Dict[UUID, Mapping[str, object]] = {row["id"]: dict(row) for row in paper_rows}
+        missing = [pid for pid in unique_ids if pid not in found_papers]
+        if missing:
+            missing_str = ", ".join(str(pid) for pid in missing)
+            raise PaperComparisonError(f"Unknown paper identifiers: {missing_str}")
+
+        result_rows = await conn.fetch(
+            """
+            SELECT
+                r.id AS result_id,
+                r.paper_id,
+                r.method_id,
+                m.name AS method_name,
+                r.dataset_id,
+                d.name AS dataset_name,
+                r.metric_id,
+                mt.name AS metric_name,
+                mt.unit AS metric_unit,
+                r.task_id,
+                t.name AS task_name,
+                r.split,
+                r.value_numeric,
+                r.value_text,
+                r.unit,
+                r.is_sota,
+                r.confidence,
+                r.evidence
+            FROM results r
+            LEFT JOIN methods m ON r.method_id = m.id
+            LEFT JOIN datasets d ON r.dataset_id = d.id
+            LEFT JOIN metrics mt ON r.metric_id = mt.id
+            LEFT JOIN tasks t ON r.task_id = t.id
+            WHERE r.paper_id = ANY($1::uuid[])
+            ORDER BY COALESCE(d.name, ''), COALESCE(mt.name, ''), COALESCE(m.name, ''), COALESCE(r.split, '')
+            """,
+            unique_ids,
+        )
+
+    papers: List[ComparisonPaper] = []
+    for pid in unique_ids:
+        paper_data = found_papers[pid]
+        title = cast(Optional[str], paper_data.get("title"))
+        year = cast(Optional[int], paper_data.get("year"))
+        papers.append(ComparisonPaper(id=pid, title=title, year=year))
+
+    entity_sets: Dict[UUID, Dict[str, Set[str]]] = {
+        pid: {
+            "methods": set(),
+            "datasets": set(),
+            "metrics": set(),
+            "tasks": set(),
+        }
+        for pid in unique_ids
+    }
+
+    matrix_map: MutableMapping[
+        Tuple[UUID | None, UUID | None, UUID | None, UUID | None, str | None],
+        ComparisonRow,
+    ] = {}
+
+    for row in result_rows:
+        paper_id: UUID = row["paper_id"]
+        method_name = row["method_name"]
+        dataset_name = row["dataset_name"]
+        metric_name = row["metric_name"]
+        task_name = row["task_name"]
+
+        if method_name:
+            entity_sets[paper_id]["methods"].add(method_name)
+        if dataset_name:
+            entity_sets[paper_id]["datasets"].add(dataset_name)
+        if metric_name:
+            entity_sets[paper_id]["metrics"].add(metric_name)
+        if task_name:
+            entity_sets[paper_id]["tasks"].add(task_name)
+
+        key = (
+            row["method_id"],
+            row["dataset_id"],
+            row["metric_id"],
+            row["task_id"],
+            row["split"],
+        )
+
+        if key not in matrix_map:
+            matrix_map[key] = ComparisonRow(
+                method_id=row["method_id"],
+                method_name=method_name,
+                dataset_id=row["dataset_id"],
+                dataset_name=dataset_name,
+                metric_id=row["metric_id"],
+                metric_name=metric_name,
+                metric_unit=row["metric_unit"],
+                task_id=row["task_id"],
+                task_name=task_name,
+                split=row["split"],
+                papers={},
+            )
+
+        numeric_value = row["value_numeric"]
+        confidence_value = row["confidence"]
+        matrix_map[key].papers[paper_id] = ComparisonCell(
+            result_id=row["result_id"],
+            value_numeric=float(numeric_value) if numeric_value is not None else None,
+            value_text=row["value_text"],
+            unit=row["unit"],
+            is_sota=row["is_sota"],
+            confidence=float(confidence_value) if confidence_value is not None else None,
+            evidence=list(row["evidence"] or []),
+        )
+
+    def build_entity_summary(field: str) -> ComparisonEntitySummary:
+        shared_values = _shared_entities(entity_sets.values(), field)
+        unique_values = _unique_entities(entity_sets, field)
+        return ComparisonEntitySummary(shared=shared_values, unique=unique_values)
+
+    summary = ComparisonSummary(
+        methods=build_entity_summary("methods"),
+        datasets=build_entity_summary("datasets"),
+        metrics=build_entity_summary("metrics"),
+        tasks=build_entity_summary("tasks"),
+    )
+
+    matrix = sorted(
+        matrix_map.values(),
+        key=lambda row: (
+            (row.dataset_name or "").lower(),
+            (row.metric_name or "").lower(),
+            (row.method_name or "").lower(),
+            (row.task_name or "").lower(),
+            row.split or "",
+        ),
+    )
+
+    return PaperComparisonResponse(papers=papers, summary=summary, matrix=matrix)
+
+
+def _shared_entities(entity_sets: Iterable[Mapping[str, Set[str]]], field: str) -> List[str]:
+    sets = [values[field] for values in entity_sets]
+    if not sets:
+        return []
+    shared = set.intersection(*sets)  # type: ignore[arg-type]
+    return sorted(shared)
+
+
+def _unique_entities(entity_sets: Mapping[UUID, Mapping[str, Set[str]]], field: str) -> Dict[UUID, List[str]]:
+    unique: Dict[UUID, List[str]] = {}
+    for paper_id, values in entity_sets.items():
+        current = set(values[field])
+        other_values: Set[str] = set()
+        for other_id, other in entity_sets.items():
+            if other_id == paper_id:
+                continue
+            other_values.update(other[field])
+        unique_values = sorted(current - other_values)
+        unique[paper_id] = unique_values
+    return unique


### PR DESCRIPTION
## Summary
- document in the compare service that the aggregation works across scientific domains
- update the compare page description to highlight multi-disciplinary support and domain-agnostic behavior

## Testing
- npm run lint *(fails: repository does not include a package.json at workspace root)*

------
https://chatgpt.com/codex/tasks/task_e_68f22c9b7704832182ae6cdb15bf90cf